### PR TITLE
Remove unwrap

### DIFF
--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -8,7 +8,7 @@ use std::fs::File;
 fn main() {
     CombinedLogger::init(
         vec![
-            TermLogger::new(LogLevelFilter::Warn),
+            TermLogger::new(LogLevelFilter::Warn).unwrap(),
             FileLogger::new(LogLevelFilter::Info, File::create("my_rust_binary.log").unwrap()),
         ]
     ).unwrap();

--- a/src/comblog.rs
+++ b/src/comblog.rs
@@ -37,7 +37,7 @@ impl CombinedLogger {
     /// # fn main() {
     /// let _ = CombinedLogger::init(
     ///             vec![
-    ///                 TermLogger::new(LogLevelFilter::Info),
+    ///                 TermLogger::new(LogLevelFilter::Info).unwrap(),
     ///                 FileLogger::new(LogLevelFilter::Info, File::create("my_rust_bin.log").unwrap())
     ///             ]
     ///         );
@@ -70,7 +70,7 @@ impl CombinedLogger {
     /// # fn main() {
     /// let combined_logger = CombinedLogger::new(
     ///             vec![
-    ///                 TermLogger::new(LogLevelFilter::Debug),
+    ///                 TermLogger::new(LogLevelFilter::Debug).unwrap(),
     ///                 FileLogger::new(LogLevelFilter::Info, File::create("my_rust_bin.log").unwrap())
     ///             ]
     ///         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,27 +78,27 @@ mod tests {
             vec![
                 //error
                 SimpleLogger::new(LogLevelFilter::Error),
-                TermLogger::new(LogLevelFilter::Error),
+                TermLogger::new(LogLevelFilter::Error).unwrap(),
                 FileLogger::new(LogLevelFilter::Error, File::create("error.log").unwrap()),
 
                 //warn
                 SimpleLogger::new(LogLevelFilter::Warn),
-                TermLogger::new(LogLevelFilter::Warn),
+                TermLogger::new(LogLevelFilter::Warn).unwrap(),
                 FileLogger::new(LogLevelFilter::Warn, File::create("warn.log").unwrap()),
 
                 //info
                 SimpleLogger::new(LogLevelFilter::Info),
-                TermLogger::new(LogLevelFilter::Info),
+                TermLogger::new(LogLevelFilter::Info).unwrap(),
                 FileLogger::new(LogLevelFilter::Info, File::create("info.log").unwrap()),
 
                 //debug
                 SimpleLogger::new(LogLevelFilter::Debug),
-                TermLogger::new(LogLevelFilter::Debug),
+                TermLogger::new(LogLevelFilter::Debug).unwrap(),
                 FileLogger::new(LogLevelFilter::Debug, File::create("debug.log").unwrap()),
 
                 //trace
                 SimpleLogger::new(LogLevelFilter::Trace),
-                TermLogger::new(LogLevelFilter::Trace),
+                TermLogger::new(LogLevelFilter::Trace).unwrap(),
                 FileLogger::new(LogLevelFilter::Trace, File::create("trace.log").unwrap()),
             ]
         ).unwrap();


### PR DESCRIPTION
I removed some `unwrap()` calls to avoid causing `panic` when not running the application in a terminal (for instance, a GUI application).