### PR TITLE
Fix compilation without default features

### DIFF
--- a/src/loggers/mod.rs
+++ b/src/loggers/mod.rs
@@ -6,6 +6,7 @@ mod comblog;
 pub mod logging;
 
 pub use self::simplelog::SimpleLogger;
+#[cfg(feature = "term")]
 pub use self::termlog::{TermLogger, TermLogError};
 pub use self::writelog::WriteLogger;
 pub use self::comblog::CombinedLogger;


### PR DESCRIPTION
It failed with this error when using without the default features:

```
error[E0432]: unresolved import `self::termlog`
 --> /home/vorner/.cargo/registry/src/github.com-1ecc6299db9ec823/simplelog-0.4.3/src/loggers/mod.rs:9:15
  |
9 | pub use self::termlog::{TermLogger, TermLogError};
  |               ^^^^^^^ Could not find `termlog` in `self`

error: aborting due to previous error

```