### PR TITLE
Configurable time format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ default = ["term"]
 [dependencies]
 log = "0.3"
 term = { version = "0.4", optional = true }
-time = "0.1"
+chrono = "0.4.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,8 +15,7 @@ use log::LogLevel;
 /// want to show the source line only on `Trace` use that.
 /// Passing `None` will completely disable the part.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Config
-{
+pub struct Config {
     ///At which level and below the current time shall be logged
     pub time: Option<LogLevel>,
     ///At which level and below the level itself shall be logged
@@ -25,6 +24,8 @@ pub struct Config
     pub target: Option<LogLevel>,
     ///At which level and below a source code reference shall be logged
     pub location: Option<LogLevel>,
+    ///A chrono strftime string. See: https://docs.rs/chrono/0.4.0/chrono/format/strftime/index.html#specifiers
+    pub time_format: Option<&'static str>,
 }
 
 impl Default for Config {
@@ -34,6 +35,7 @@ impl Default for Config {
             level: Some(LogLevel::Error),
             target: Some(LogLevel::Debug),
             location: Some(LogLevel::Trace),
+            time_format: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 #[macro_use] extern crate log;
 #[cfg(feature = "term")]
 extern crate term;
-extern crate time;
+extern crate chrono;
 
 mod config;
 mod loggers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ mod tests {
                     level: None,
                     target: None,
                     location: None,
+                    time_format: None,
                 };
 
                 for elem in vec![None, Some(LogLevel::Trace), Some(LogLevel::Debug), Some(LogLevel::Info), Some(LogLevel::Warn), Some(LogLevel::Error)]

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -10,7 +10,7 @@ pub fn try_log<W>(config: &Config, record: &LogRecord, write: &mut W) -> Result<
 
     if let Some(time) = config.time {
         if time <= record.level() {
-            try!(write_time(write));
+            try!(write_time(write, config));
         }
     }
 
@@ -38,12 +38,15 @@ pub fn try_log<W>(config: &Config, record: &LogRecord, write: &mut W) -> Result<
 }
 
 #[inline(always)]
-pub fn write_time<W>(write: &mut W) -> Result<(), Error>
+pub fn write_time<W>(write: &mut W, config: &Config) -> Result<(), Error>
     where W: Write + Sized
 {
     let cur_time = chrono::Utc::now();
-    try!(write!(write, "{} ",
-                cur_time.format("%H:%M:%S"),));
+    try!(write!(write, "{} ", cur_time.format(
+            config
+                .time_format
+                .unwrap_or("%H:%M:%S")
+    )));
     Ok(())
 }
 

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -1,5 +1,5 @@
 use log::LogRecord;
-use time;
+use chrono;
 use std::io::{Write, Error};
 use ::Config;
 
@@ -41,11 +41,9 @@ pub fn try_log<W>(config: &Config, record: &LogRecord, write: &mut W) -> Result<
 pub fn write_time<W>(write: &mut W) -> Result<(), Error>
     where W: Write + Sized
 {
-    let cur_time = time::now();
-    try!(write!(write, "{:02}:{:02}:{:02} ",
-                cur_time.tm_hour,
-                cur_time.tm_min,
-                cur_time.tm_sec));
+    let cur_time = chrono::Utc::now();
+    try!(write!(write, "{} ",
+                cur_time.format("%H:%M:%S"),));
     Ok(())
 }
 

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -125,7 +125,7 @@ impl TermLogger
 
         if let Some(time) = self.config.time {
             if time <= record.level() {
-                try!(write_time(&mut *term_lock));
+                try!(write_time(&mut *term_lock, &self.config));
             }
         }
 


### PR DESCRIPTION
Add the time_format config option which will be used as the format string for writing the time.

I also replaced the `time` crate with `chrono` (https://github.com/chronotope/chrono) because it's more well supported.

https://github.com/Drakulix/simplelog.rs/issues/12