### PR TITLE
Update for log 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ include = [
 default = ["term"]
 
 [dependencies]
-log = "0.3"
+log = { version = "0.4", features = ["std"] }
 term = { version = "0.4", optional = true }
 chrono = "0.4.0"

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -8,8 +8,8 @@ use std::fs::File;
 fn main() {
     CombinedLogger::init(
         vec![
-            TermLogger::new(LogLevelFilter::Warn, Config::default()).unwrap(),
-            WriteLogger::new(LogLevelFilter::Info, Config::default(), File::create("my_rust_binary.log").unwrap()),
+            TermLogger::new(LevelFilter::Warn, Config::default()).unwrap(),
+            WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_binary.log").unwrap()),
         ]
     ).unwrap();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use log::LogLevel;
+use log::Level;
 
 /// Configuration for the Loggers
 ///
@@ -7,23 +7,23 @@ use log::LogLevel;
 /// Every space delimited part except the actual message is optional.
 ///
 /// Pass this struct to your logger to change when these information shall
-/// be logged. Every part can be enabled for a specific LogLevel and is then
+/// be logged. Every part can be enabled for a specific Level and is then
 /// automatically enable for all lower levels as well.
 ///
 /// The Result is that the logging gets more detailed the more verbose it gets.
-/// E.g. to have one part shown always use `LogLevel::Error`. But if you
+/// E.g. to have one part shown always use `Level::Error`. But if you
 /// want to show the source line only on `Trace` use that.
 /// Passing `None` will completely disable the part.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Config {
     ///At which level and below the current time shall be logged
-    pub time: Option<LogLevel>,
+    pub time: Option<Level>,
     ///At which level and below the level itself shall be logged
-    pub level: Option<LogLevel>,
+    pub level: Option<Level>,
     ///At which level and below the target shall be logged
-    pub target: Option<LogLevel>,
+    pub target: Option<Level>,
     ///At which level and below a source code reference shall be logged
-    pub location: Option<LogLevel>,
+    pub location: Option<Level>,
     ///A chrono strftime string. See: https://docs.rs/chrono/0.4.0/chrono/format/strftime/index.html#specifiers
     pub time_format: Option<&'static str>,
 }
@@ -31,10 +31,10 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            time: Some(LogLevel::Error),
-            level: Some(LogLevel::Error),
-            target: Some(LogLevel::Debug),
-            location: Some(LogLevel::Trace),
+            time: Some(Level::Error),
+            level: Some(Level::Error),
+            target: Some(Level::Debug),
+            location: Some(Level::Trace),
             time_format: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,17 +33,17 @@ pub use self::loggers::{SimpleLogger, WriteLogger, CombinedLogger};
 #[cfg(feature = "term")]
 pub use self::loggers::{TermLogger, TermLogError};
 
-pub use log::{LogLevel, LogLevelFilter};
+pub use log::{Level, LevelFilter};
 
 use log::Log;
 
-/// Trait to have a common interface to obtain the LogLevel of Loggers
+/// Trait to have a common interface to obtain the Level of Loggers
 ///
 /// Necessary for CombinedLogger to calculate
-/// the lowest used LogLevel.
+/// the lowest used Level.
 ///
 pub trait SharedLogger: Log {
-    /// Returns the set LogLevel for this Logger
+    /// Returns the set Level for this Logger
     ///
     /// # Examples
     ///
@@ -51,11 +51,11 @@ pub trait SharedLogger: Log {
     /// # extern crate simplelog;
     /// # use simplelog::*;
     /// # fn main() {
-    /// let logger = SimpleLogger::new(LogLevelFilter::Info, Config::default());
+    /// let logger = SimpleLogger::new(LevelFilter::Info, Config::default());
     /// println!("{}", logger.level());
     /// # }
     /// ```
-    fn level(&self) -> LogLevelFilter;
+    fn level(&self) -> LevelFilter;
 
     /// Inspect the config of a running Logger
     ///
@@ -67,7 +67,7 @@ pub trait SharedLogger: Log {
     /// # extern crate simplelog;
     /// # use simplelog::*;
     /// # fn main() {
-    /// let logger = SimpleLogger::new(LogLevelFilter::Info, Config::default());
+    /// let logger = SimpleLogger::new(LevelFilter::Info, Config::default());
     /// println!("{:?}", logger.config());
     /// # }
     /// ```
@@ -99,7 +99,7 @@ mod tests {
                     time_format: None,
                 };
 
-                for elem in vec![None, Some(LogLevel::Trace), Some(LogLevel::Debug), Some(LogLevel::Info), Some(LogLevel::Warn), Some(LogLevel::Error)]
+                for elem in vec![None, Some(Level::Trace), Some(Level::Debug), Some(Level::Info), Some(Level::Warn), Some(Level::Error)]
                 {
                     conf.location = elem;
                     conf.target = elem;
@@ -108,29 +108,29 @@ mod tests {
                     i += 1;
 
                     //error
-                    vec.push(SimpleLogger::new(LogLevelFilter::Error, conf) as Box<SharedLogger>);
-                    vec.push(TermLogger::new(LogLevelFilter::Error, conf).unwrap() as Box<SharedLogger>);
-                    vec.push(WriteLogger::new(LogLevelFilter::Error, conf, File::create(&format!("error_{}.log", i)).unwrap()) as Box<SharedLogger>);
+                    vec.push(SimpleLogger::new(LevelFilter::Error, conf) as Box<SharedLogger>);
+                    vec.push(TermLogger::new(LevelFilter::Error, conf).unwrap() as Box<SharedLogger>);
+                    vec.push(WriteLogger::new(LevelFilter::Error, conf, File::create(&format!("error_{}.log", i)).unwrap()) as Box<SharedLogger>);
 
                     //warn
-                    vec.push(SimpleLogger::new(LogLevelFilter::Warn, conf) as Box<SharedLogger>);
-                    vec.push(TermLogger::new(LogLevelFilter::Warn, conf).unwrap() as Box<SharedLogger>);
-                    vec.push(WriteLogger::new(LogLevelFilter::Warn, conf, File::create(&format!("warn_{}.log", i)).unwrap()) as Box<SharedLogger>);
+                    vec.push(SimpleLogger::new(LevelFilter::Warn, conf) as Box<SharedLogger>);
+                    vec.push(TermLogger::new(LevelFilter::Warn, conf).unwrap() as Box<SharedLogger>);
+                    vec.push(WriteLogger::new(LevelFilter::Warn, conf, File::create(&format!("warn_{}.log", i)).unwrap()) as Box<SharedLogger>);
 
                     //info
-                    vec.push(SimpleLogger::new(LogLevelFilter::Info, conf) as Box<SharedLogger>);
-                    vec.push(TermLogger::new(LogLevelFilter::Info, conf).unwrap() as Box<SharedLogger>);
-                    vec.push(WriteLogger::new(LogLevelFilter::Info, conf, File::create(&format!("info_{}.log", i)).unwrap()) as Box<SharedLogger>);
+                    vec.push(SimpleLogger::new(LevelFilter::Info, conf) as Box<SharedLogger>);
+                    vec.push(TermLogger::new(LevelFilter::Info, conf).unwrap() as Box<SharedLogger>);
+                    vec.push(WriteLogger::new(LevelFilter::Info, conf, File::create(&format!("info_{}.log", i)).unwrap()) as Box<SharedLogger>);
 
                     //debug
-                    vec.push(SimpleLogger::new(LogLevelFilter::Debug, conf) as Box<SharedLogger>);
-                    vec.push(TermLogger::new(LogLevelFilter::Debug, conf).unwrap() as Box<SharedLogger>);
-                    vec.push(WriteLogger::new(LogLevelFilter::Debug, conf, File::create(&format!("debug_{}.log", i)).unwrap()) as Box<SharedLogger>);
+                    vec.push(SimpleLogger::new(LevelFilter::Debug, conf) as Box<SharedLogger>);
+                    vec.push(TermLogger::new(LevelFilter::Debug, conf).unwrap() as Box<SharedLogger>);
+                    vec.push(WriteLogger::new(LevelFilter::Debug, conf, File::create(&format!("debug_{}.log", i)).unwrap()) as Box<SharedLogger>);
 
                     //trace
-                    vec.push(SimpleLogger::new(LogLevelFilter::Trace, conf) as Box<SharedLogger>);
-                    vec.push(TermLogger::new(LogLevelFilter::Trace, conf).unwrap() as Box<SharedLogger>);
-                    vec.push(WriteLogger::new(LogLevelFilter::Trace, conf, File::create(&format!("trace_{}.log", i)).unwrap()) as Box<SharedLogger>);
+                    vec.push(SimpleLogger::new(LevelFilter::Trace, conf) as Box<SharedLogger>);
+                    vec.push(TermLogger::new(LevelFilter::Trace, conf).unwrap() as Box<SharedLogger>);
+                    vec.push(WriteLogger::new(LevelFilter::Trace, conf, File::create(&format!("trace_{}.log", i)).unwrap()) as Box<SharedLogger>);
                 }
 
                 vec

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -33,7 +33,6 @@ pub fn try_log<W>(config: &Config, record: &Record, write: &mut W) -> Result<(),
     }
 
     try!(write_args(record, write));
-    try!(write.flush());
     Ok(())
 }
 

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -1,10 +1,10 @@
-use log::LogRecord;
+use log::Record;
 use chrono;
 use std::io::{Write, Error};
 use ::Config;
 
 #[inline(always)]
-pub fn try_log<W>(config: &Config, record: &LogRecord, write: &mut W) -> Result<(), Error>
+pub fn try_log<W>(config: &Config, record: &Record, write: &mut W) -> Result<(), Error>
     where W: Write + Sized
 {
 
@@ -51,7 +51,7 @@ pub fn write_time<W>(write: &mut W, config: &Config) -> Result<(), Error>
 }
 
 #[inline(always)]
-pub fn write_level<W>(record: &LogRecord, write: &mut W) -> Result<(), Error>
+pub fn write_level<W>(record: &Record, write: &mut W) -> Result<(), Error>
     where W: Write + Sized
 {
     try!(write!(write, "[{}] ", record.level()));
@@ -59,7 +59,7 @@ pub fn write_level<W>(record: &LogRecord, write: &mut W) -> Result<(), Error>
 }
 
 #[inline(always)]
-pub fn write_target<W>(record: &LogRecord, write: &mut W) -> Result<(), Error>
+pub fn write_target<W>(record: &Record, write: &mut W) -> Result<(), Error>
     where W: Write + Sized
 {
     try!(write!(write, "{}: ", record.target()));
@@ -67,17 +67,20 @@ pub fn write_target<W>(record: &LogRecord, write: &mut W) -> Result<(), Error>
 }
 
 #[inline(always)]
-pub fn write_location<W>(record: &LogRecord, write: &mut W) -> Result<(), Error>
+pub fn write_location<W>(record: &Record, write: &mut W) -> Result<(), Error>
     where W: Write + Sized
 {
-    try!(write!(write, "[{}:{}] ",
-        record.location().file(),
-        record.location().line()));
+    let file = record.file().unwrap_or("<unknown>");
+    if let Some(line) = record.line() {
+        try!(write!(write, "[{}:{}] ", file, line));
+    } else {
+        try!(write!(write, "[{}:<unknown>] ", file));
+    }
     Ok(())
 }
 
 #[inline(always)]
-pub fn write_args<W>(record: &LogRecord, write: &mut W) -> Result<(), Error>
+pub fn write_args<W>(record: &Record, write: &mut W) -> Result<(), Error>
     where W: Write + Sized
 {
     try!(writeln!(write, "{}", record.args()));

--- a/src/loggers/simplelog.rs
+++ b/src/loggers/simplelog.rs
@@ -81,9 +81,10 @@ impl Log for SimpleLogger {
         }
     }
 
-    /// The `Log::log` implementation internally calls `try_log` which always
-    /// flushes so this does nothing.
-    fn flush(&self) { }
+    fn flush(&self) {
+        use std::io::Write;
+        let _ = stdout().flush();
+    }
 }
 
 impl SharedLogger for SimpleLogger {

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -148,7 +148,6 @@ impl TermLogger
         }
 
         try!(write_args(record, &mut *term_lock));
-        try!(term_lock.flush());
         Ok(())
     }
 
@@ -175,9 +174,10 @@ impl Log for TermLogger
         let _ = self.try_log(record);
     }
 
-    /// The `Log::log` implementation internally calls `try_log_term` which
-    /// always flushes so this does nothing.
-    fn flush(&self) { }
+    fn flush(&self) {
+        let _ = self.stdout.lock().unwrap().flush();
+        let _ = self.stderr.lock().unwrap().flush();
+    }
 }
 
 impl SharedLogger for TermLogger

--- a/src/loggers/writelog.rs
+++ b/src/loggers/writelog.rs
@@ -76,9 +76,9 @@ impl<W: Write + Send + 'static> Log for WriteLogger<W> {
         }
     }
 
-    /// The `Log::log` implementation internally calls `try_log` which always
-    /// flushes so this does nothing.
-    fn flush(&self) { }
+    fn flush(&self) {
+        let _ = self.writable.lock().unwrap().flush();
+    }
 }
 
 impl<W: Write + Send + 'static> SharedLogger for WriteLogger<W> {


### PR DESCRIPTION
Initializing with a Box<Log> now uses the 'log::set_boxed_logger'
function which is feature gated behind the "std" feature.

Log implementations now define 'flush' method, which does nothing since
all loggers already flush in 'try_log'.

Records now can possibly fail to produce a file or line location, in
which case " &lt;unknown&gt;" will be displayed.