### PR TITLE
Dependency Upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+    - Updated `simplelog` to `log` 0.4.1
+    - Updated `simplelog` to `term` 0.5.1
+    - Fixed compiler warning about unused `#[macro_use]`
+
 ## v0.5.0
     - Update `simplelog` to `log` 0.4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ include = [
 default = ["term"]
 
 [dependencies]
-log = { version = "0.4", features = ["std"] }
-term = { version = "0.4", optional = true }
+log = { version = "0.4.1", features = ["std"] }
+term = { version = "0.5.1", optional = true }
 chrono = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@
 
 #![deny(missing_docs)]
 
-#[macro_use] extern crate log;
+#[cfg_attr(test, macro_use)]
+extern crate log;
 #[cfg(feature = "term")]
 extern crate term;
 extern crate chrono;


### PR DESCRIPTION
Updated to the latest versions of `log` and `term`, this was specifically because the latest version of `term` uses the `0.3+` version of winapi on Windows.

Also fixed a compiler warning about the unused macro import on `log` since the macros were only used in unit tests.