### PR TITLE
Added a thread id output.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"editor.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"editor.formatOnSave": false
-}

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,8 @@ pub struct Config {
     pub time: Option<Level>,
     ///At which level and below the level itself shall be logged
     pub level: Option<Level>,
+	///At which level and below the thread id shall be logged. Default DEBUG
+	pub thread: Option<Level>,
     ///At which level and below the target shall be logged
     pub target: Option<Level>,
     ///At which level and below a source code reference shall be logged
@@ -33,6 +35,7 @@ impl Default for Config {
         Config {
             time: Some(Level::Error),
             level: Some(Level::Error),
+			thread: Some(Level::Debug),
             target: Some(Level::Debug),
             location: Some(Level::Trace),
             time_format: None,

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -1,25 +1,25 @@
-use log::Record;
 use chrono;
-use std::io::{Write, Error};
+use log::Record;
+use std::io::{Error, Write};
 use std::thread;
-use ::Config;
+use Config;
 
 #[inline(always)]
 pub fn try_log<W>(config: &Config, record: &Record, write: &mut W) -> Result<(), Error>
-    where W: Write + Sized
+where
+	W: Write + Sized,
 {
+	if let Some(time) = config.time {
+		if time <= record.level() {
+			try!(write_time(write, config));
+		}
+	}
 
-    if let Some(time) = config.time {
-        if time <= record.level() {
-            try!(write_time(write, config));
-        }
-    }
-
-    if let Some(level) = config.level {
-        if level <= record.level() {
-            try!(write_level(record, write));
-        }
-    }
+	if let Some(level) = config.level {
+		if level <= record.level() {
+			try!(write_level(record, write));
+		}
+	}
 
 	if let Some(thread) = config.thread {
 		if thread <= record.level() {
@@ -27,78 +27,84 @@ pub fn try_log<W>(config: &Config, record: &Record, write: &mut W) -> Result<(),
 		}
 	}
 
-    if let Some(target) = config.target {
-        if target <= record.level() {
-            try!(write_target(record, write));
-        }
-    }
+	if let Some(target) = config.target {
+		if target <= record.level() {
+			try!(write_target(record, write));
+		}
+	}
 
-    if let Some(location) = config.location {
-        if location <= record.level() {
-            try!(write_location(record, write));
-        }
-    }
+	if let Some(location) = config.location {
+		if location <= record.level() {
+			try!(write_location(record, write));
+		}
+	}
 
-    try!(write_args(record, write));
-    Ok(())
+	try!(write_args(record, write));
+	Ok(())
 }
 
 #[inline(always)]
 pub fn write_time<W>(write: &mut W, config: &Config) -> Result<(), Error>
-    where W: Write + Sized
+where
+	W: Write + Sized,
 {
-    let cur_time = chrono::Utc::now();
-    try!(write!(write, "{} ", cur_time.format(
-            config
-                .time_format
-                .unwrap_or("%H:%M:%S")
-    )));
-    Ok(())
+	let cur_time = chrono::Utc::now();
+	try!(write!(
+		write,
+		"{} ",
+		cur_time.format(config.time_format.unwrap_or("%H:%M:%S"))
+	));
+	Ok(())
 }
 
 #[inline(always)]
 pub fn write_level<W>(record: &Record, write: &mut W) -> Result<(), Error>
-    where W: Write + Sized
+where
+	W: Write + Sized,
 {
-    try!(write!(write, "[{}] ", record.level()));
-    Ok(())
+	try!(write!(write, "[{}] ", record.level()));
+	Ok(())
 }
 
 #[inline(always)]
 pub fn write_target<W>(record: &Record, write: &mut W) -> Result<(), Error>
-    where W: Write + Sized
+where
+	W: Write + Sized,
 {
-    try!(write!(write, "{}: ", record.target()));
-    Ok(())
+	try!(write!(write, "{}: ", record.target()));
+	Ok(())
 }
 
 #[inline(always)]
 pub fn write_location<W>(record: &Record, write: &mut W) -> Result<(), Error>
-    where W: Write + Sized
+where
+	W: Write + Sized,
 {
-    let file = record.file().unwrap_or("<unknown>");
-    if let Some(line) = record.line() {
-        try!(write!(write, "[{}:{}] ", file, line));
-    } else {
-        try!(write!(write, "[{}:<unknown>] ", file));
-    }
-    Ok(())
+	let file = record.file().unwrap_or("<unknown>");
+	if let Some(line) = record.line() {
+		try!(write!(write, "[{}:{}] ", file, line));
+	} else {
+		try!(write!(write, "[{}:<unknown>] ", file));
+	}
+	Ok(())
 }
 
 #[inline(always)]
 pub fn write_args<W>(record: &Record, write: &mut W) -> Result<(), Error>
-    where W: Write + Sized
+where
+	W: Write + Sized,
 {
-    try!(writeln!(write, "{}", record.args()));
-    Ok(())
+	try!(writeln!(write, "{}", record.args()));
+	Ok(())
 }
 
 pub fn write_thread_id<W>(_record: &Record, write: &mut W) -> Result<(), Error>
-	where W: Write + Sized
+where
+	W: Write + Sized,
 {
-	let id = format!("{:?}",  thread::current().id());
+	let id = format!("{:?}", thread::current().id());
 	let id = id.replace("ThreadId(", "");
-	let id = id.replace(")", "");	
+	let id = id.replace(")", "");
 	try!(write!(write, "({}) ", id));
 	Ok(())
 }

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -1,218 +1,223 @@
 //! Module providing the TermLogger Implementation
 
-use log::{Level, LevelFilter, Metadata, Record, SetLoggerError, set_boxed_logger, set_max_level, Log};
-use term;
-use term::{StderrTerminal, StdoutTerminal, Terminal, color};
+use log::{
+	set_boxed_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record, SetLoggerError,
+};
 use std::error;
 use std::fmt;
+use std::io::{Error, Write};
 use std::sync::Mutex;
-use std::io::{Write, Error};
+use term;
+use term::{color, StderrTerminal, StdoutTerminal, Terminal};
 
 use self::TermLogError::{SetLogger, Term};
 use super::logging::*;
 
-use ::{Config, SharedLogger};
+use {Config, SharedLogger};
 
 /// TermLogger error type.
 #[derive(Debug)]
 pub enum TermLogError {
-    ///The type returned by set_logger if set_logger has already been called.
-    SetLogger(SetLoggerError),
+	///The type returned by set_logger if set_logger has already been called.
+	SetLogger(SetLoggerError),
 
-    ///TermLogger initialization might also fail if stdout or stderr could not be opened,
-    ///e.g. when no tty is attached to the process, it runs detached in the background, etc
-    /// This is represented by the `Term` Kind
-    Term,
+	///TermLogger initialization might also fail if stdout or stderr could not be opened,
+	///e.g. when no tty is attached to the process, it runs detached in the background, etc
+	/// This is represented by the `Term` Kind
+	Term,
 }
 
 impl fmt::Display for TermLogError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::error::Error as FmtError;
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		use std::error::Error as FmtError;
 
-        write!(f, "{}", self.description())
-    }
+		write!(f, "{}", self.description())
+	}
 }
 
 impl error::Error for TermLogError {
-    fn description(&self) -> &str {
-        match * self {
-            SetLogger(ref err) => err.description(),
-            Term => "A terminal could not be opened",
-        }
-    }
+	fn description(&self) -> &str {
+		match *self {
+			SetLogger(ref err) => err.description(),
+			Term => "A terminal could not be opened",
+		}
+	}
 
-    fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            SetLogger(ref err) => Some(err),
-            Term => None,
-        }
-    }
+	fn cause(&self) -> Option<&error::Error> {
+		match *self {
+			SetLogger(ref err) => Some(err),
+			Term => None,
+		}
+	}
 }
 
 impl From<SetLoggerError> for TermLogError {
-    fn from(error: SetLoggerError) -> Self {
-        SetLogger(error)
-    }
+	fn from(error: SetLoggerError) -> Self {
+		SetLogger(error)
+	}
 }
 
 struct OutputStreams {
-    stderr: Box<StderrTerminal>,
-    stdout: Box<StdoutTerminal>,
+	stderr: Box<StderrTerminal>,
+	stdout: Box<StdoutTerminal>,
 }
 
 /// The TermLogger struct. Provides a stderr/out based Logger implementation
 ///
 /// Supports colored output
 pub struct TermLogger {
-    level: LevelFilter,
-    config: Config,
-    streams: Mutex<OutputStreams>,
+	level: LevelFilter,
+	config: Config,
+	streams: Mutex<OutputStreams>,
 }
 
-impl TermLogger
-{
-    /// init function. Globally initializes the TermLogger as the one and only used log facility.
-    ///
-    /// Takes the desired `Level` and `Config` as arguments. They cannot be changed later on.
-    /// Fails if another Logger was already initialized.
-    ///
-    /// # Examples
-    /// ```
-    /// # extern crate simplelog;
-    /// # use simplelog::*;
-    /// # fn main() {
-    /// let _ = TermLogger::init(LevelFilter::Info, Config::default());
-    /// # }
-    /// ```
-    pub fn init(log_level: LevelFilter, config: Config) -> Result<(), TermLogError> {
-        let logger = try!(TermLogger::new(log_level, config).ok_or(Term));
-        set_max_level(log_level.clone());
-        try!(set_boxed_logger(logger));
-        Ok(())
-    }
+impl TermLogger {
+	/// init function. Globally initializes the TermLogger as the one and only used log facility.
+	///
+	/// Takes the desired `Level` and `Config` as arguments. They cannot be changed later on.
+	/// Fails if another Logger was already initialized.
+	///
+	/// # Examples
+	/// ```
+	/// # extern crate simplelog;
+	/// # use simplelog::*;
+	/// # fn main() {
+	/// let _ = TermLogger::init(LevelFilter::Info, Config::default());
+	/// # }
+	/// ```
+	pub fn init(log_level: LevelFilter, config: Config) -> Result<(), TermLogError> {
+		let logger = try!(TermLogger::new(log_level, config).ok_or(Term));
+		set_max_level(log_level.clone());
+		try!(set_boxed_logger(logger));
+		Ok(())
+	}
 
-    /// allows to create a new logger, that can be independently used, no matter whats globally set.
-    ///
-    /// no macros are provided for this case and you probably
-    /// dont want to use this function, but `init()`, if you dont want to build a `CombinedLogger`.
-    ///
-    /// Takes the desired `Level` and `Config` as arguments. They cannot be changed later on.
-    ///
-    /// # Examples
-    /// ```
-    /// # extern crate simplelog;
-    /// # use simplelog::*;
-    /// # fn main() {
-    /// let term_logger = TermLogger::new(LevelFilter::Info, Config::default()).unwrap();
-    /// # }
-    /// ```
-    pub fn new(log_level: LevelFilter, config: Config) -> Option<Box<TermLogger>> {
-        term::stderr().and_then(|stderr|
-            term::stdout().map(|stdout| {
-                let streams = Mutex::new( OutputStreams {
-                    stderr: stderr,
-                    stdout: stdout,
-                });
-                Box::new(TermLogger { level: log_level, config: config, streams: streams
-                })
-            })
-        )
-    }
+	/// allows to create a new logger, that can be independently used, no matter whats globally set.
+	///
+	/// no macros are provided for this case and you probably
+	/// dont want to use this function, but `init()`, if you dont want to build a `CombinedLogger`.
+	///
+	/// Takes the desired `Level` and `Config` as arguments. They cannot be changed later on.
+	///
+	/// # Examples
+	/// ```
+	/// # extern crate simplelog;
+	/// # use simplelog::*;
+	/// # fn main() {
+	/// let term_logger = TermLogger::new(LevelFilter::Info, Config::default()).unwrap();
+	/// # }
+	/// ```
+	pub fn new(log_level: LevelFilter, config: Config) -> Option<Box<TermLogger>> {
+		term::stderr().and_then(|stderr| {
+			term::stdout().map(|stdout| {
+				let streams = Mutex::new(OutputStreams {
+					stderr: stderr,
+					stdout: stdout,
+				});
+				Box::new(TermLogger {
+					level: log_level,
+					config: config,
+					streams: streams,
+				})
+			})
+		})
+	}
 
-    fn try_log_term<W>(&self, record: &Record, term_lock: &mut Box<Terminal<Output=W> + Send>) -> Result<(), Error>
-        where W: Write + Sized
-    {
-        let color = match record.level() {
-            Level::Error => color::RED,
-            Level::Warn => color::YELLOW,
-            Level::Info => color::BLUE,
-            Level::Debug => color::CYAN,
-            Level::Trace => color::WHITE
-        };
+	fn try_log_term<W>(
+		&self,
+		record: &Record,
+		term_lock: &mut Box<Terminal<Output = W> + Send>,
+	) -> Result<(), Error>
+	where
+		W: Write + Sized,
+	{
+		let color = match record.level() {
+			Level::Error => color::RED,
+			Level::Warn => color::YELLOW,
+			Level::Info => color::BLUE,
+			Level::Debug => color::CYAN,
+			Level::Trace => color::WHITE,
+		};
 
-        if let Some(time) = self.config.time {
-            if time <= record.level() {
-                try!(write_time(&mut *term_lock, &self.config));
-            }
-        }
+		if let Some(time) = self.config.time {
+			if time <= record.level() {
+				try!(write_time(&mut *term_lock, &self.config));
+			}
+		}
 
-        if let Some(level) = self.config.level {
-            if level <= record.level() {
-                try!(term_lock.fg(color));
-                try!(write_level(record, &mut *term_lock));
-                try!(term_lock.reset());
-            }
-        }
+		if let Some(level) = self.config.level {
+			if level <= record.level() {
+				try!(term_lock.fg(color));
+				try!(write_level(record, &mut *term_lock));
+				try!(term_lock.reset());
+			}
+		}
 
 		if let Some(thread) = self.config.thread {
 			if thread <= record.level() {
 				try!(term_lock.fg(color));
-				 try!(write_thread_id(record, &mut *term_lock));
-                try!(term_lock.reset());
+				try!(write_thread_id(record, &mut *term_lock));
+				try!(term_lock.reset());
 			}
 		}
 
-        if let Some(target) = self.config.target {
-            if target <= record.level() {
-                try!(write_target(record, &mut *term_lock));
-            }
-        }
+		if let Some(target) = self.config.target {
+			if target <= record.level() {
+				try!(write_target(record, &mut *term_lock));
+			}
+		}
 
-        if let Some(location) = self.config.location {
-            if location <= record.level() {
-                try!(write_location(record, &mut *term_lock));
-            }
-        }
+		if let Some(location) = self.config.location {
+			if location <= record.level() {
+				try!(write_location(record, &mut *term_lock));
+			}
+		}
 
-        try!(write_args(record, &mut *term_lock));
-        Ok(())
-    }
+		try!(write_args(record, &mut *term_lock));
+		Ok(())
+	}
 
-    fn try_log(&self, record: &Record) -> Result<(), Error> {
-        if self.enabled(record.metadata()) {
+	fn try_log(&self, record: &Record) -> Result<(), Error> {
+		if self.enabled(record.metadata()) {
+			let mut streams = self.streams.lock().unwrap();
 
-            let mut streams = self.streams.lock().unwrap();
-
-            if record.level() == Level::Error {
-                self.try_log_term(record, &mut streams.stderr)
-            } else {
-                self.try_log_term(record, &mut streams.stdout)
-            }
-        } else {
-            Ok(())
-        }
-    }
+			if record.level() == Level::Error {
+				self.try_log_term(record, &mut streams.stderr)
+			} else {
+				self.try_log_term(record, &mut streams.stdout)
+			}
+		} else {
+			Ok(())
+		}
+	}
 }
 
-impl Log for TermLogger
-{
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() <= self.level
-    }
+impl Log for TermLogger {
+	fn enabled(&self, metadata: &Metadata) -> bool {
+		metadata.level() <= self.level
+	}
 
-    fn log(&self, record: &Record) {
-        let _ = self.try_log(record);
-    }
+	fn log(&self, record: &Record) {
+		let _ = self.try_log(record);
+	}
 
-    fn flush(&self) {
-        let mut streams = self.streams.lock().unwrap();
-        let _ = streams.stdout.flush();
-        let _ = streams.stderr.flush();
-    }
+	fn flush(&self) {
+		let mut streams = self.streams.lock().unwrap();
+		let _ = streams.stdout.flush();
+		let _ = streams.stderr.flush();
+	}
 }
 
-impl SharedLogger for TermLogger
-{
-    fn level(&self) -> LevelFilter {
-        self.level
-    }
+impl SharedLogger for TermLogger {
+	fn level(&self) -> LevelFilter {
+		self.level
+	}
 
-    fn config(&self) -> Option<&Config>
-    {
-        Some(&self.config)
-    }
+	fn config(&self) -> Option<&Config> {
+		Some(&self.config)
+	}
 
-    fn as_log(self: Box<Self>) -> Box<Log> {
-        Box::new(*self)
-    }
+	fn as_log(self: Box<Self>) -> Box<Log> {
+		Box::new(*self)
+	}
 }

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -144,6 +144,14 @@ impl TermLogger
             }
         }
 
+		if let Some(thread) = self.config.thread {
+			if thread <= record.level() {
+				try!(term_lock.fg(color));
+				 try!(write_thread_id(record, &mut *term_lock));
+                try!(term_lock.reset());
+			}
+		}
+
         if let Some(target) = self.config.target {
             if target <= record.level() {
                 try!(write_target(record, &mut *term_lock));


### PR DESCRIPTION
Added a thread id output such that the output follows `<time> <level> <thread_id>`.

Thread id comes from [`std::thread::current().id()`](https://doc.rust-lang.org/std/thread/struct.ThreadId.html) as a `ThreadId` which, for now, is backed by a `u64`.

I decided to output the id as a number, encased in brackets. I am not too fussed about the format. `ThreadId` does not implement `Display` so I have deconstructed the debug format to return just the number (debug output is `ThreadId(#)`).

I decided to use the string replace function rather than take a slice `&id[9..id.len()-1]` as there may be no guarantee that the debug format remains constant.

😄 