### PR TITLE
update a deb for minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ default = ["term"]
 [dependencies]
 log = { version = "0.4.1", features = ["std"] }
 term = { version = "0.5.1", optional = true }
-chrono = "0.4.0"
+chrono = "0.4.6"


### PR DESCRIPTION
This bumps the minimal acceptable versions in Cargo.toml to versions that are compatible with `-Z minimal-versions`. This is part of the process of seeing how hard this is for crates to use in preparation for getting it stabilized for use in CI, specifically upstreaming the changes required to get criterion working with it. It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them.