### PR TITLE
implemented allow and ignore filtering

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,13 @@ pub struct Config {
     pub location: Option<Level>,
     ///A chrono strftime string. See: https://docs.rs/chrono/0.4.0/chrono/format/strftime/index.html#specifiers
     pub time_format: Option<&'static str>,
+
+    /// Allowed module filters
+    /// If specified, only records from modules starting with one of these entries will be printed
+    pub filter_allow: Option<&'static [&'static str]>,
+    /// Denied module filters
+    /// If specified, records from modules starting with one of these entries will be ignored
+    pub filter_ignore: Option<&'static [&'static str]>,
 }
 
 impl Default for Config {
@@ -36,6 +43,8 @@ impl Default for Config {
             target: Some(Level::Debug),
             location: Some(Level::Trace),
             time_format: None,
+            filter_allow: None,
+            filter_ignore: None,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,11 +27,15 @@ pub struct Config {
     ///A chrono strftime string. See: https://docs.rs/chrono/0.4.0/chrono/format/strftime/index.html#specifiers
     pub time_format: Option<&'static str>,
 
-    /// Allowed module filters
+    /// Allowed module filters.
     /// If specified, only records from modules starting with one of these entries will be printed
+    /// 
+    /// For example, `filter_allow: Some(&["tokio::uds"])` would allow only logging from the `tokio` crates `uds` module.
     pub filter_allow: Option<&'static [&'static str]>,
-    /// Denied module filters
+    /// Denied module filters.
     /// If specified, records from modules starting with one of these entries will be ignored
+    /// 
+    /// For example, `filter_ignore: Some(&["tokio::uds"])` would deny logging from the `tokio` crates `uds` module.
     pub filter_ignore: Option<&'static [&'static str]>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,8 @@ mod tests {
                     target: None,
                     location: None,
                     time_format: None,
+                    filter_allow: None,
+                    filter_ignore: None,
                 };
 
                 for elem in vec![None, Some(Level::Trace), Some(Level::Debug), Some(Level::Info), Some(Level::Warn), Some(Level::Error)]

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -161,7 +161,12 @@ impl TermLogger
     }
 
     fn try_log(&self, record: &Record) -> Result<(), Error> {
+        
         if self.enabled(record.metadata()) {
+
+            if should_skip(&self.config, record) {
+                return Ok(())
+            }
 
             let mut streams = self.streams.lock().unwrap();
 


### PR DESCRIPTION
This allows the specification of a allowed or ignored modules for logging using the configuration `filter_allow` and `filter_ignore` fields, somewhat mitigating #3.

As this introduces new fields to an object that can be publicly constructed (eg. using `Config{..}`), this is a _breaking_ change. If you wanted to mitigate this in future i would suggest moving to a builder pattern for constructing the `Config` object and adding a private field to disable public construction.