### PR TITLE
Document why TermLogger::new could return None

### DIFF
--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -133,6 +133,8 @@ impl TermLogger {
     ///
     /// Takes the desired `Level` and `Config` as arguments. They cannot be changed later on.
     ///
+    /// Returns a `Box`ed TermLogger, or None if a terminal couldn't be opened.
+    ///
     /// # Examples
     /// ```
     /// # extern crate simplelog;


### PR DESCRIPTION
See issue #40 