### PR TITLE
Extended functionality for filter_allow and filter_ignore

### DIFF
--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -110,8 +110,8 @@ where
 #[inline(always)]
 pub fn should_skip(config: &Config, record: &Record<'_>) -> bool {
     // If a module path and allowed list are available
-    match (record.module_path(), &*config.filter_allow) {
-        (Some(path), allowed) if allowed.len() > 0 => {
+    match (record.target(), &*config.filter_allow) {
+        (path, allowed) if allowed.len() > 0 => {
             // Check that the module path matches at least one allow filter
             if let None = allowed.iter().find(|v| path.starts_with(&***v)) {
                 // If not, skip any further writing
@@ -122,8 +122,8 @@ pub fn should_skip(config: &Config, record: &Record<'_>) -> bool {
     }
 
     // If a module path and ignore list are available
-    match (record.module_path(), &*config.filter_ignore) {
-        (Some(path), ignore) if ignore.len() > 0 => {
+    match (record.target(), &*config.filter_ignore) {
+        (path, ignore) if ignore.len() > 0 => {
             // Check that the module path does not match any ignore filters
             if let Some(_) = ignore.iter().find(|v| path.starts_with(&***v)) {
                 // If not, skip any further writing


### PR DESCRIPTION
By using the `target()` method instead of `module_path()` we can extend the functionality of the `add_filter_allow` and `add_filter_ignore` to the case where the target is set manually and not defaulted to the module_path. This preserves the current functionality since if that `target` is not set, it defaults to the `module_path` as per the `log` crate spec:

> A log request consists of a target, a level, and a body. A target is a string which defaults to the module path of the location of the log request, though that default may be overridden. Logger implementations typically use the target to filter requests based on some user configuration.

