### PR TITLE
Derive useful traits for the terminal mode type.

### DIFF
--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -77,6 +77,7 @@ struct OutputStreams {
 }
 
 /// Specifies which streams should be used when logging
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum TerminalMode {
     /// Only use Stdout
     Stdout,


### PR DESCRIPTION
`TerminalMode` is just a plain enum, I see no reason for preventing it from having implementations of `Copy`, `Eq`, `Debug` and `Hash`. Without it, it is not possible to easily embed it in other types for which we wish to derive these traits as well (a case that I stumbled upon in my project).