### PR TITLE
Migrate to termcolor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   matrix:
     - FEATURES=""
     - FEATURES="test"
-    - FEATURES="term"
+    - FEATURES="termcolor"
     - FEATURES="default"
     - FEATURES="all"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ include = [
 
 [features]
 test = []
-default = ["term"]
+default = ["termcolor"]
 
 [dependencies]
 log = { version = "0.4.*", features = ["std"] }
-term = { version = ">=0.5.1, <0.7.0", optional = true }
+termcolor = { version = "1.1.*", optional = true }
 chrono = "0.4.*"

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -5,9 +5,9 @@ use std::fs::File;
 
 fn main() {
     CombinedLogger::init(vec![
-        #[cfg(feature = "term")]
+        #[cfg(feature = "termcolor")]
         TermLogger::new(LevelFilter::Warn, Config::default(), TerminalMode::Mixed),
-        #[cfg(not(feature = "term"))]
+        #[cfg(not(feature = "termcolor"))]
         SimpleLogger::new(LevelFilter::Warn, Config::default()),
         WriteLogger::new(
             LevelFilter::Info,

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 fn main() {
     CombinedLogger::init(vec![
         #[cfg(feature = "term")]
-        TermLogger::new(LevelFilter::Warn, Config::default(), TerminalMode::Mixed).unwrap(),
+        TermLogger::new(LevelFilter::Warn, Config::default(), TerminalMode::Mixed),
         #[cfg(not(feature = "term"))]
         SimpleLogger::new(LevelFilter::Warn, Config::default()),
         WriteLogger::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ mod tests {
                 );
                 #[cfg(feature = "term")]
                 vec.push(
-                    TermLogger::new(LevelFilter::Error, conf.clone(), TerminalMode::Mixed).unwrap()
+                    TermLogger::new(LevelFilter::Error, conf.clone(), TerminalMode::Mixed)
                         as Box<dyn SharedLogger>,
                 );
                 vec.push(WriteLogger::new(
@@ -141,7 +141,7 @@ mod tests {
                 );
                 #[cfg(feature = "term")]
                 vec.push(
-                    TermLogger::new(LevelFilter::Warn, conf.clone(), TerminalMode::Mixed).unwrap()
+                    TermLogger::new(LevelFilter::Warn, conf.clone(), TerminalMode::Mixed)
                         as Box<dyn SharedLogger>,
                 );
                 vec.push(WriteLogger::new(
@@ -158,7 +158,7 @@ mod tests {
                 );
                 #[cfg(feature = "term")]
                 vec.push(
-                    TermLogger::new(LevelFilter::Info, conf.clone(), TerminalMode::Mixed).unwrap()
+                    TermLogger::new(LevelFilter::Info, conf.clone(), TerminalMode::Mixed)
                         as Box<dyn SharedLogger>,
                 );
                 vec.push(WriteLogger::new(
@@ -175,7 +175,7 @@ mod tests {
                 );
                 #[cfg(feature = "term")]
                 vec.push(
-                    TermLogger::new(LevelFilter::Debug, conf.clone(), TerminalMode::Mixed).unwrap()
+                    TermLogger::new(LevelFilter::Debug, conf.clone(), TerminalMode::Mixed)
                         as Box<dyn SharedLogger>,
                 );
                 vec.push(WriteLogger::new(
@@ -192,7 +192,7 @@ mod tests {
                 );
                 #[cfg(feature = "term")]
                 vec.push(
-                    TermLogger::new(LevelFilter::Trace, conf.clone(), TerminalMode::Mixed).unwrap()
+                    TermLogger::new(LevelFilter::Trace, conf.clone(), TerminalMode::Mixed)
                         as Box<dyn SharedLogger>,
                 );
                 vec.push(WriteLogger::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use self::config::{Config, ConfigBuilder, LevelPadding, ThreadPadding, Threa
 #[cfg(feature = "test")]
 pub use self::loggers::TestLogger;
 pub use self::loggers::{CombinedLogger, SimpleLogger, WriteLogger};
-#[cfg(feature = "term")]
+#[cfg(feature = "termcolor")]
 pub use self::loggers::{TermLogError, TermLogger, TerminalMode};
 
 pub use log::{Level, LevelFilter};
@@ -122,7 +122,7 @@ mod tests {
                 vec.push(
                     SimpleLogger::new(LevelFilter::Error, conf.clone()) as Box<dyn SharedLogger>
                 );
-                #[cfg(feature = "term")]
+                #[cfg(feature = "termcolor")]
                 vec.push(
                     TermLogger::new(LevelFilter::Error, conf.clone(), TerminalMode::Mixed)
                         as Box<dyn SharedLogger>,
@@ -139,7 +139,7 @@ mod tests {
                 vec.push(
                     SimpleLogger::new(LevelFilter::Warn, conf.clone()) as Box<dyn SharedLogger>
                 );
-                #[cfg(feature = "term")]
+                #[cfg(feature = "termcolor")]
                 vec.push(
                     TermLogger::new(LevelFilter::Warn, conf.clone(), TerminalMode::Mixed)
                         as Box<dyn SharedLogger>,
@@ -156,7 +156,7 @@ mod tests {
                 vec.push(
                     SimpleLogger::new(LevelFilter::Info, conf.clone()) as Box<dyn SharedLogger>
                 );
-                #[cfg(feature = "term")]
+                #[cfg(feature = "termcolor")]
                 vec.push(
                     TermLogger::new(LevelFilter::Info, conf.clone(), TerminalMode::Mixed)
                         as Box<dyn SharedLogger>,
@@ -173,7 +173,7 @@ mod tests {
                 vec.push(
                     SimpleLogger::new(LevelFilter::Debug, conf.clone()) as Box<dyn SharedLogger>
                 );
-                #[cfg(feature = "term")]
+                #[cfg(feature = "termcolor")]
                 vec.push(
                     TermLogger::new(LevelFilter::Debug, conf.clone(), TerminalMode::Mixed)
                         as Box<dyn SharedLogger>,
@@ -190,7 +190,7 @@ mod tests {
                 vec.push(
                     SimpleLogger::new(LevelFilter::Trace, conf.clone()) as Box<dyn SharedLogger>
                 );
-                #[cfg(feature = "term")]
+                #[cfg(feature = "termcolor")]
                 vec.push(
                     TermLogger::new(LevelFilter::Trace, conf.clone(), TerminalMode::Mixed)
                         as Box<dyn SharedLogger>,

--- a/src/loggers/comblog.rs
+++ b/src/loggers/comblog.rs
@@ -37,7 +37,7 @@ impl CombinedLogger {
     /// let _ = CombinedLogger::init(
     ///             vec![
     /// #               #[cfg(feature = "term")]
-    ///                 TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed).unwrap(),
+    ///                 TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed),
     ///                 WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_bin.log").unwrap())
     ///             ]
     ///         );
@@ -68,7 +68,7 @@ impl CombinedLogger {
     /// let combined_logger = CombinedLogger::new(
     ///             vec![
     /// #               #[cfg(feature = "term")]
-    ///                 TermLogger::new(LevelFilter::Debug, Config::default(), TerminalMode::Mixed).unwrap(),
+    ///                 TermLogger::new(LevelFilter::Debug, Config::default(), TerminalMode::Mixed),
     ///                 WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_bin.log").unwrap())
     ///             ]
     ///         );

--- a/src/loggers/comblog.rs
+++ b/src/loggers/comblog.rs
@@ -36,7 +36,7 @@ impl CombinedLogger {
     /// # fn main() {
     /// let _ = CombinedLogger::init(
     ///             vec![
-    /// #               #[cfg(feature = "term")]
+    /// #               #[cfg(feature = "termcolor")]
     ///                 TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed),
     ///                 WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_bin.log").unwrap())
     ///             ]
@@ -67,7 +67,7 @@ impl CombinedLogger {
     /// # fn main() {
     /// let combined_logger = CombinedLogger::new(
     ///             vec![
-    /// #               #[cfg(feature = "term")]
+    /// #               #[cfg(feature = "termcolor")]
     ///                 TermLogger::new(LevelFilter::Debug, Config::default(), TerminalMode::Mixed),
     ///                 WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_bin.log").unwrap())
     ///             ]

--- a/src/loggers/mod.rs
+++ b/src/loggers/mod.rs
@@ -1,7 +1,7 @@
 mod comblog;
 pub mod logging;
 mod simplelog;
-#[cfg(feature = "term")]
+#[cfg(feature = "termcolor")]
 mod termlog;
 #[cfg(feature = "test")]
 mod testlog;
@@ -9,7 +9,7 @@ mod writelog;
 
 pub use self::comblog::CombinedLogger;
 pub use self::simplelog::SimpleLogger;
-#[cfg(feature = "term")]
+#[cfg(feature = "termcolor")]
 pub use self::termlog::{TermLogError, TermLogger, TerminalMode};
 #[cfg(feature = "test")]
 pub use self::testlog::TestLogger;

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -7,8 +7,6 @@ use std::error;
 use std::fmt;
 use std::io::{Error, Write};
 use std::sync::Mutex;
-// use term;
-// use term::{color, StderrTerminal, StdoutTerminal, Terminal};
 use termcolor;
 use termcolor::{StandardStream, ColorChoice, Color, WriteColor, ColorSpec};
 
@@ -220,9 +218,7 @@ impl TermLogger {
         }
 
         if self.config.level <= record.level() && self.config.level != LevelFilter::Off {
-            let mut color_spec = ColorSpec::new();
-            color_spec.set_fg(Some(color));
-            term_lock.set_color(&color_spec)?;
+            term_lock.set_color(ColorSpec::new().set_fg(Some(color)))?;
             write_level(record, &mut *term_lock, &self.config)?;
             term_lock.reset()?;
         }


### PR DESCRIPTION
Change the dependency of `term` to `termcolor` now that `term` is no longer maintained as per https://github.com/Drakulix/simplelog.rs/issues/54.

It seems `termcolor` is slightly unreliable on macOS and sometimes doesn't colour the output, but I can't reliably reproduce it. It works fine on Windows and Ubuntu.

Also `termcolor` doesn't throw an error (at least during my tests) if it can't open stdout so I've removed the `Option` from `TermLogger::new()`

Fixes #54 