### PR TITLE
Remove unwrap() on TermLogger::new() in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ use std::fs::File;
 fn main() {
     CombinedLogger::init(
         vec![
-            TermLogger::new(LevelFilter::Warn, Config::default(), TerminalMode::Mixed).unwrap(),
+            TermLogger::new(LevelFilter::Warn, Config::default(), TerminalMode::Mixed),
             WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_binary.log").unwrap()),
         ]
     ).unwrap();


### PR DESCRIPTION
The example from the README didn't work. While this is still different from usage.rs, it compiles.