### PR TITLE
Customizable level label colors

### DIFF
--- a/examples/custom_colors.rs
+++ b/examples/custom_colors.rs
@@ -1,0 +1,22 @@
+use log::*;
+use simplelog::*;
+
+#[cfg(feature = "termcolor")]
+fn main() {
+    let config = ConfigBuilder::new()
+        .set_level_color(Level::Error, Color::Magenta)
+        .set_level_color(Level::Trace, Color::Green)
+        .build();
+
+    TermLogger::init(LevelFilter::Trace, config, TerminalMode::Stdout).unwrap();
+    error!("Magenta error");
+    warn!("Yellow warning");
+    info!("Blue info");
+    debug!("Cyan debug");
+    trace!("Green trace");
+}
+
+#[cfg(not(feature = "termcolor"))]
+fn main() {
+    println!("this example requires the termcolor feature.");
+}

--- a/examples/default_colors.rs
+++ b/examples/default_colors.rs
@@ -1,0 +1,17 @@
+use log::*;
+use simplelog::*;
+
+#[cfg(feature = "termcolor")]
+fn main() {
+    TermLogger::init(LevelFilter::Trace, Config::default(), TerminalMode::Stdout).unwrap();
+    error!("Red error");
+    warn!("Yellow warning");
+    info!("Blue info");
+    debug!("Cyan debug");
+    trace!("White trace");
+}
+
+#[cfg(not(feature = "termcolor"))]
+fn main() {
+    println!("this example requires the termcolor feature.");
+}

--- a/examples/rgb_colors.rs
+++ b/examples/rgb_colors.rs
@@ -1,0 +1,25 @@
+use log::*;
+use simplelog::*;
+
+#[cfg(all(not(target_family = "windows"), feature = "termcolor"))]
+fn main() {
+    let config = ConfigBuilder::new()
+        .set_level_color(Level::Error, Color::Rgb(191, 0, 0))
+        .set_level_color(Level::Warn,  Color::Rgb(255, 127, 0))
+        .set_level_color(Level::Info,  Color::Rgb(192, 192, 0))
+        .set_level_color(Level::Debug, Color::Rgb(63, 127, 0))
+        .set_level_color(Level::Trace, Color::Rgb(127, 127, 255))
+        .build();
+
+    TermLogger::init(LevelFilter::Trace, config, TerminalMode::Stdout).unwrap();
+    error!("Red error");
+    warn!("Orange warning");
+    info!("Yellow info");
+    debug!("Dark green debug");
+    trace!("Light blue trace");
+}
+
+#[cfg(any(target_family = "windows", not(feature = "termcolor")))]
+fn main() {
+    println!("this example requires the termcolor feature and a non-Windows OS.");
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
-use log::LevelFilter;
+use log::{Level, LevelFilter};
 
 pub use chrono::offset::{FixedOffset, Local, Offset, TimeZone, Utc};
+#[cfg(feature = "termcolor")]
+use termcolor::Color;
 use std::borrow::Cow;
 
 #[derive(Debug, Clone, Copy)]
@@ -61,6 +63,8 @@ pub struct Config {
     pub(crate) time_local: bool,
     pub(crate) filter_allow: Cow<'static, [Cow<'static, str>]>,
     pub(crate) filter_ignore: Cow<'static, [Cow<'static, str>]>,
+    #[cfg(feature = "termcolor")]
+    pub(crate) level_color: [Color; 6],
 }
 
 /// Builder for the Logger Configurations (`Config`)
@@ -130,6 +134,13 @@ impl ConfigBuilder {
     /// Set the mode for logging the thread
     pub fn set_thread_mode<'a>(&'a mut self, mode: ThreadLogMode) -> &'a mut ConfigBuilder {
         self.0.thread_log_mode = mode;
+        self
+    }
+
+    /// Set the color used for printing the level (if the logger supports it)
+    #[cfg(feature = "termcolor")]
+    pub fn set_level_color<'a>(&'a mut self, level: Level, color: Color) -> &'a mut ConfigBuilder {
+        self.0.level_color[level as usize] = color;
         self
     }
 
@@ -250,6 +261,16 @@ impl Default for Config {
             time_local: false,
             filter_allow: Cow::Borrowed(&[]),
             filter_ignore: Cow::Borrowed(&[]),
+
+            #[cfg(feature = "termcolor")]
+            level_color: [
+                Color::White,  // (dummy)
+                Color::Red,    // Error
+                Color::Yellow, // Warn
+                Color::Blue,   // Info
+                Color::Cyan,   // Debug
+                Color::White,  // Trace
+            ],
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub use self::loggers::TestLogger;
 pub use self::loggers::{CombinedLogger, SimpleLogger, WriteLogger};
 #[cfg(feature = "termcolor")]
 pub use self::loggers::{TermLogError, TermLogger, TerminalMode};
+#[cfg(feature = "termcolor")]
+pub use termcolor::Color;
 
 pub use log::{Level, LevelFilter};
 

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::io::{Error, Write};
 use std::sync::Mutex;
 use termcolor;
-use termcolor::{StandardStream, ColorChoice, Color, WriteColor, ColorSpec};
+use termcolor::{StandardStream, ColorChoice, WriteColor, ColorSpec};
 
 use self::TermLogError::{SetLogger};
 use super::logging::*;
@@ -170,13 +170,7 @@ impl TermLogger {
         record: &Record<'_>,
         term_lock: &mut Box<dyn WriteColor + Send>,
     ) -> Result<(), Error> {
-        let color = match record.level() {
-            Level::Error => Color::Red,
-            Level::Warn => Color::Yellow,
-            Level::Info => Color::Blue,
-            Level::Debug => Color::Cyan,
-            Level::Trace => Color::White,
-        };
+        let color = self.config.level_color[record.level() as usize];
 
         if self.config.time <= record.level() && self.config.time != LevelFilter::Off {
             write_time(&mut *term_lock, &self.config)?;


### PR DESCRIPTION
- Added `ConfigBuilder::set_level_color` to customize the colors of level labels for loggers that support color. 
- Added three examples showing the default colors, custom colors, and (if supported) RGB colors.
- Tested with and without the `termcolor` feature enabled.