### PR TITLE
Expose termcolor's ColorChoice and make colors optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplelog"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2018"
 authors = ["Drakulix <github@drakulix.de>"]
 description = "A simple and easy-to-use logging facility for Rust's log crate"

--- a/examples/custom_colors.rs
+++ b/examples/custom_colors.rs
@@ -8,7 +8,7 @@ fn main() {
         .set_level_color(Level::Trace, Some(Color::Green))
         .build();
 
-    TermLogger::init(LevelFilter::Trace, config, TerminalMode::Stdout).unwrap();
+    TermLogger::init(LevelFilter::Trace, config, TerminalMode::Stdout, ColorChoice::Auto).unwrap();
     error!("Magenta error");
     warn!("Yellow warning");
     info!("Blue info");

--- a/examples/custom_colors.rs
+++ b/examples/custom_colors.rs
@@ -4,8 +4,8 @@ use simplelog::*;
 #[cfg(feature = "termcolor")]
 fn main() {
     let config = ConfigBuilder::new()
-        .set_level_color(Level::Error, Color::Magenta)
-        .set_level_color(Level::Trace, Color::Green)
+        .set_level_color(Level::Error, Some(Color::Magenta))
+        .set_level_color(Level::Trace, Some(Color::Green))
         .build();
 
     TermLogger::init(LevelFilter::Trace, config, TerminalMode::Stdout).unwrap();

--- a/examples/default_colors.rs
+++ b/examples/default_colors.rs
@@ -3,7 +3,12 @@ use simplelog::*;
 
 #[cfg(feature = "termcolor")]
 fn main() {
-    TermLogger::init(LevelFilter::Trace, Config::default(), TerminalMode::Stdout).unwrap();
+    TermLogger::init(
+        LevelFilter::Trace,
+        Config::default(),
+        TerminalMode::Stdout,
+        ColorChoice::Auto
+    ).unwrap();
     error!("Red error");
     warn!("Yellow warning");
     info!("Blue info");

--- a/examples/rgb_colors.rs
+++ b/examples/rgb_colors.rs
@@ -11,7 +11,12 @@ fn main() {
         .set_level_color(Level::Trace, Some(Color::Rgb(127, 127, 255)))
         .build();
 
-    TermLogger::init(LevelFilter::Trace, config, TerminalMode::Stdout).unwrap();
+    TermLogger::init(
+        LevelFilter::Trace,
+        config,
+        TerminalMode::Stdout,
+        ColorChoice::Auto
+    ).unwrap();
     error!("Red error");
     warn!("Orange warning");
     info!("Yellow info");

--- a/examples/rgb_colors.rs
+++ b/examples/rgb_colors.rs
@@ -4,11 +4,11 @@ use simplelog::*;
 #[cfg(all(not(target_family = "windows"), feature = "termcolor"))]
 fn main() {
     let config = ConfigBuilder::new()
-        .set_level_color(Level::Error, Color::Rgb(191, 0, 0))
-        .set_level_color(Level::Warn,  Color::Rgb(255, 127, 0))
-        .set_level_color(Level::Info,  Color::Rgb(192, 192, 0))
-        .set_level_color(Level::Debug, Color::Rgb(63, 127, 0))
-        .set_level_color(Level::Trace, Color::Rgb(127, 127, 255))
+        .set_level_color(Level::Error, Some(Color::Rgb(191, 0, 0)))
+        .set_level_color(Level::Warn,  Some(Color::Rgb(255, 127, 0)))
+        .set_level_color(Level::Info,  Some(Color::Rgb(192, 192, 0)))
+        .set_level_color(Level::Debug, Some(Color::Rgb(63, 127, 0)))
+        .set_level_color(Level::Trace, Some(Color::Rgb(127, 127, 255)))
         .build();
 
     TermLogger::init(LevelFilter::Trace, config, TerminalMode::Stdout).unwrap();

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -6,7 +6,12 @@ use std::fs::File;
 fn main() {
     CombinedLogger::init(vec![
         #[cfg(feature = "termcolor")]
-        TermLogger::new(LevelFilter::Warn, Config::default(), TerminalMode::Mixed),
+        TermLogger::new(
+            LevelFilter::Warn,
+            Config::default(),
+            TerminalMode::Mixed,
+            ColorChoice::Auto
+        ),
         #[cfg(not(feature = "termcolor"))]
         SimpleLogger::new(LevelFilter::Warn, Config::default()),
         WriteLogger::new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,7 +64,7 @@ pub struct Config {
     pub(crate) filter_allow: Cow<'static, [Cow<'static, str>]>,
     pub(crate) filter_ignore: Cow<'static, [Cow<'static, str>]>,
     #[cfg(feature = "termcolor")]
-    pub(crate) level_color: [Color; 6],
+    pub(crate) level_color: [Option<Color>; 6],
 }
 
 /// Builder for the Logger Configurations (`Config`)
@@ -138,9 +138,10 @@ impl ConfigBuilder {
         self
     }
 
-    /// Set the color used for printing the level (if the logger supports it)
+    /// Set the color used for printing the level (if the logger supports it),
+    /// or None to use the default foreground color
     #[cfg(feature = "termcolor")]
-    pub fn set_level_color<'a>(&'a mut self, level: Level, color: Color) -> &'a mut ConfigBuilder {
+    pub fn set_level_color<'a>(&'a mut self, level: Level, color: Option<Color>) -> &'a mut ConfigBuilder {
         self.0.level_color[level as usize] = color;
         self
     }
@@ -265,12 +266,12 @@ impl Default for Config {
 
             #[cfg(feature = "termcolor")]
             level_color: [
-                Color::White,  // (dummy)
-                Color::Red,    // Error
-                Color::Yellow, // Warn
-                Color::Blue,   // Info
-                Color::Cyan,   // Debug
-                Color::White,  // Trace
+                None,                // Default foreground
+                Some(Color::Red),    // Error
+                Some(Color::Yellow), // Warn
+                Some(Color::Blue),   // Info
+                Some(Color::Cyan),   // Debug
+                Some(Color::White),  // Trace
             ],
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use self::loggers::{CombinedLogger, SimpleLogger, WriteLogger};
 #[cfg(feature = "termcolor")]
 pub use self::loggers::{TermLogger, TerminalMode};
 #[cfg(feature = "termcolor")]
-pub use termcolor::Color;
+pub use termcolor::{Color, ColorChoice};
 
 pub use log::{Level, LevelFilter};
 
@@ -126,7 +126,7 @@ mod tests {
                 );
                 #[cfg(feature = "termcolor")]
                 vec.push(
-                    TermLogger::new(LevelFilter::Error, conf.clone(), TerminalMode::Mixed)
+                    TermLogger::new(LevelFilter::Error, conf.clone(), TerminalMode::Mixed, ColorChoice::Auto)
                         as Box<dyn SharedLogger>,
                 );
                 vec.push(WriteLogger::new(
@@ -143,7 +143,7 @@ mod tests {
                 );
                 #[cfg(feature = "termcolor")]
                 vec.push(
-                    TermLogger::new(LevelFilter::Warn, conf.clone(), TerminalMode::Mixed)
+                    TermLogger::new(LevelFilter::Warn, conf.clone(), TerminalMode::Mixed, ColorChoice::Auto)
                         as Box<dyn SharedLogger>,
                 );
                 vec.push(WriteLogger::new(
@@ -160,7 +160,7 @@ mod tests {
                 );
                 #[cfg(feature = "termcolor")]
                 vec.push(
-                    TermLogger::new(LevelFilter::Info, conf.clone(), TerminalMode::Mixed)
+                    TermLogger::new(LevelFilter::Info, conf.clone(), TerminalMode::Mixed, ColorChoice::Auto)
                         as Box<dyn SharedLogger>,
                 );
                 vec.push(WriteLogger::new(
@@ -177,7 +177,7 @@ mod tests {
                 );
                 #[cfg(feature = "termcolor")]
                 vec.push(
-                    TermLogger::new(LevelFilter::Debug, conf.clone(), TerminalMode::Mixed)
+                    TermLogger::new(LevelFilter::Debug, conf.clone(), TerminalMode::Mixed, ColorChoice::Auto)
                         as Box<dyn SharedLogger>,
                 );
                 vec.push(WriteLogger::new(
@@ -194,7 +194,7 @@ mod tests {
                 );
                 #[cfg(feature = "termcolor")]
                 vec.push(
-                    TermLogger::new(LevelFilter::Trace, conf.clone(), TerminalMode::Mixed)
+                    TermLogger::new(LevelFilter::Trace, conf.clone(), TerminalMode::Mixed, ColorChoice::Auto)
                         as Box<dyn SharedLogger>,
                 );
                 vec.push(WriteLogger::new(

--- a/src/loggers/comblog.rs
+++ b/src/loggers/comblog.rs
@@ -37,7 +37,7 @@ impl CombinedLogger {
     /// let _ = CombinedLogger::init(
     ///             vec![
     /// #               #[cfg(feature = "termcolor")]
-    ///                 TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed),
+    ///                 TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed, ColorChoice::Auto),
     ///                 WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_bin.log").unwrap())
     ///             ]
     ///         );
@@ -68,7 +68,7 @@ impl CombinedLogger {
     /// let combined_logger = CombinedLogger::new(
     ///             vec![
     /// #               #[cfg(feature = "termcolor")]
-    ///                 TermLogger::new(LevelFilter::Debug, Config::default(), TerminalMode::Mixed),
+    ///                 TermLogger::new(LevelFilter::Debug, Config::default(), TerminalMode::Mixed, ColorChoice::Auto),
     ///                 WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_bin.log").unwrap())
     ///             ]
     ///         );

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -139,7 +139,7 @@ impl TermLogger {
         }
 
         if self.config.level <= record.level() && self.config.level != LevelFilter::Off {
-            term_lock.set_color(ColorSpec::new().set_fg(Some(color)))?;
+            term_lock.set_color(ColorSpec::new().set_fg(color))?;
             write_level(record, &mut *term_lock, &self.config)?;
             term_lock.reset()?;
         }

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -68,15 +68,21 @@ impl TermLogger {
     /// # extern crate simplelog;
     /// # use simplelog::*;
     /// # fn main() {
-    ///     TermLogger::init(LevelFilter::Info, Config::default(), TerminalMode::Mixed);
+    ///     TermLogger::init(
+    ///         LevelFilter::Info,
+    ///         Config::default(),
+    ///         TerminalMode::Mixed,
+    ///         ColorChoice::Auto
+    ///     );
     /// # }
     /// ```
     pub fn init(
         log_level: LevelFilter,
         config: Config,
         mode: TerminalMode,
+        color_choice: ColorChoice
     ) -> Result<(), SetLoggerError> {
-        let logger = TermLogger::new(log_level, config, mode);
+        let logger = TermLogger::new(log_level, config, mode, color_choice);
         set_max_level(log_level.clone());
         set_boxed_logger(logger)?;
         Ok(())
@@ -96,26 +102,32 @@ impl TermLogger {
     /// # extern crate simplelog;
     /// # use simplelog::*;
     /// # fn main() {
-    /// let term_logger = TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed);
+    /// let term_logger = TermLogger::new(
+    ///     LevelFilter::Info,
+    ///     Config::default(),
+    ///     TerminalMode::Mixed,
+    ///     ColorChoice::Auto
+    /// );
     /// # }
     /// ```
     pub fn new(
         log_level: LevelFilter,
         config: Config,
         mode: TerminalMode,
+        color_choice: ColorChoice
     ) -> Box<TermLogger> {
         let streams = match mode {
             TerminalMode::Stdout => OutputStreams {
-                err: StdTerminal::Stdout(Box::new(StandardStream::stdout(ColorChoice::Always))),
-                out: StdTerminal::Stdout(Box::new(StandardStream::stdout(ColorChoice::Always)))
+                err: StdTerminal::Stdout(Box::new(StandardStream::stdout(color_choice))),
+                out: StdTerminal::Stdout(Box::new(StandardStream::stdout(color_choice)))
             },
             TerminalMode::Stderr => OutputStreams {
-                err: StdTerminal::Stderr(Box::new(StandardStream::stderr(ColorChoice::Always))),
-                out: StdTerminal::Stderr(Box::new(StandardStream::stderr(ColorChoice::Always)))
+                err: StdTerminal::Stderr(Box::new(StandardStream::stderr(color_choice))),
+                out: StdTerminal::Stderr(Box::new(StandardStream::stderr(color_choice)))
             },
             TerminalMode::Mixed => OutputStreams {
-                err: StdTerminal::Stderr(Box::new(StandardStream::stderr(ColorChoice::Always))),
-                out: StdTerminal::Stdout(Box::new(StandardStream::stdout(ColorChoice::Always)))
+                err: StdTerminal::Stderr(Box::new(StandardStream::stderr(color_choice))),
+                out: StdTerminal::Stdout(Box::new(StandardStream::stdout(color_choice)))
             },
         };
 


### PR DESCRIPTION
- **TermLogger: Expose termcolor::ColorChoice**

  Command line interfaces that write colored output usually give users
  an option to turn it off, or make it automatically shut off when writing
  to a file, pipe, or unsupported terminal. termcolor already has some
  nice machinery to handle this sort of thing with ColorChoice, so expose
  it when creating a TermLogger.

  Programmers (such as myself) who use simplelog and want to give users
  this choice only have ugly alternatives. For example, you could fall
  back to a WriteLogger if the user doesn't want color, but then you:

  - Lose out on the "mixed" logging mode you get from TerminalMode::Mixed

  - Have to reimplement nice ColorChoice::Auto behavior yourself,
    on _top_ of termcolor.

- **TermLogger/ConfigBuilder: Make colors optional**

  White isn't a good default for those with light terminal screens
  (brighter background, darker text). This is already trivial in
  termcolor, so just allow level colors to be None.

