### PR TITLE
Update README.md to conform to v0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ use std::fs::File;
 fn main() {
     CombinedLogger::init(
         vec![
-            TermLogger::new(LevelFilter::Warn, Config::default(), TerminalMode::Mixed),
+            TermLogger::new(LevelFilter::Warn, Config::default(), TerminalMode::Mixed, ColorChoice::Auto),
             WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_binary.log").unwrap()),
         ]
     ).unwrap();


### PR DESCRIPTION
Add `ColorChoice::Auto` to arguments for creating a `TermLogger`, as per v0.10 changes.