### PR TITLE
TermLogger: Use termcolor::BufferedStandardStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplelog"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2018"
 authors = ["Drakulix <github@drakulix.de>"]
 description = "A simple and easy-to-use logging facility for Rust's log crate"


### PR DESCRIPTION
Without it, termcolor issues _many, many_ small writes. This
increases performance by several orders of magnitude, at least on Linux.
Users should call `log::Log::flush()` to flush the log as-desired.