### PR TITLE
TermLogger: Flush each entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplelog"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2018"
 authors = ["Drakulix <github@drakulix.de>"]
 description = "A simple and easy-to-use logging facility for Rust's log crate"


### PR DESCRIPTION
The log crate holds the logger as a `static mut` reference
which isn't dropped at program exit:
https://doc.rust-lang.org/reference/items/static-items.html
Sadly, this means we can't rely on the BufferedStandardStreams flushing
themselves on the way out, so to avoid the Case of the Missing 8k,
flush each entry.

Fixes #80