### PR TITLE
paris: use a paris also for write_level

### DIFF
--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -5,7 +5,9 @@ use log::{
 };
 use std::io::{Error, Write};
 use std::sync::Mutex;
-use termcolor::{BufferedStandardStream, ColorChoice, ColorSpec, WriteColor};
+use termcolor::{BufferedStandardStream, ColorChoice};
+#[cfg(not(feature = "paris"))]
+use termcolor::{ColorSpec, WriteColor};
 
 use super::logging::*;
 
@@ -128,6 +130,7 @@ impl TermLogger {
         record: &Record<'_>,
         term_lock: &mut BufferedStandardStream,
     ) -> Result<(), Error> {
+        #[cfg(not(feature = "paris"))]
         let color = self.config.level_color[record.level() as usize];
 
         if self.config.time <= record.level() && self.config.time != LevelFilter::Off {
@@ -135,8 +138,12 @@ impl TermLogger {
         }
 
         if self.config.level <= record.level() && self.config.level != LevelFilter::Off {
+            #[cfg(not(feature = "paris"))]
             term_lock.set_color(ColorSpec::new().set_fg(color))?;
+
             write_level(record, term_lock, &self.config)?;
+
+            #[cfg(not(feature = "paris"))]
             term_lock.reset()?;
         }
 


### PR DESCRIPTION
Hi Victor,
I've prepared another PR:
```
If we are using paris feature to have a colored terminal (and log),
then it is also nice to have a levels colored in the log as well.

This way one can easily view created log in a similar look (with colors)
as it is printed real-time on a terminal.

Tip: To view the log with colors using 'less' you can use:
less -R /path/to/log
```
And then I can easily scroll back/see my program log as in terminal and the log level colors are doing its job:
![image](https://user-images.githubusercontent.com/583157/140640138-cc9915f0-8cd0-4c02-b72a-65a69bb815e4.png)
