### PR TITLE
introduce colored log levels using ansi_term

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ default = ["termcolor"]
 log = { version = "0.4.*", features = ["std"] }
 termcolor = { version = "1.1.*", optional = true }
 paris = { version = "1.5.7", optional = true }
+ansi_term = { version = "0.12", optional = true }
 chrono = "0.4.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -196,6 +196,7 @@ impl ConfigBuilder {
     }
 
     /// set if you want to write colors in the logfile (default is Off)
+    #[cfg(feature = "ansi_term")]
     pub fn set_write_log_enable_colors(&mut self, local: bool) -> &mut ConfigBuilder {
         self.0.write_log_enable_colors = local;
         self

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,7 @@ pub struct Config {
     pub(crate) filter_ignore: Cow<'static, [Cow<'static, str>]>,
     #[cfg(feature = "termcolor")]
     pub(crate) level_color: [Option<Color>; 6],
+    pub(crate) write_log_enable_colors: bool,
 }
 
 /// Builder for the Logger Configurations (`Config`)
@@ -194,6 +195,12 @@ impl ConfigBuilder {
         self
     }
 
+    /// set if you want to write colors in the logfile (default is Off)
+    pub fn set_write_log_enable_colors(&mut self, local: bool) -> &mut ConfigBuilder {
+        self.0.write_log_enable_colors = local;
+        self
+    }
+
     /// Add allowed module filters.
     /// If any are specified, only records from modules starting with one of these entries will be printed
     ///
@@ -281,6 +288,7 @@ impl Default for Config {
             time_local: false,
             filter_allow: Cow::Borrowed(&[]),
             filter_ignore: Cow::Borrowed(&[]),
+            write_log_enable_colors: false,
 
             #[cfg(feature = "termcolor")]
             level_color: [

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -82,7 +82,13 @@ where
 {
     #[cfg(all(feature = "termcolor", feature = "ansi_term"))]
     let color = match &config.level_color[record.level() as usize] {
-        Some(termcolor) => termcolor_to_ansiterm(termcolor),
+        Some(termcolor) => {
+            if config.write_log_enable_colors {
+                termcolor_to_ansiterm(termcolor)
+            } else {
+                None
+            }
+        }
         None => None,
     };
 

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -3,6 +3,23 @@ use crate::{Config, LevelPadding, ThreadLogMode, ThreadPadding};
 use log::{LevelFilter, Record};
 use std::io::{Error, Write};
 use std::thread;
+#[cfg(all(feature = "termcolor", feature = "ansi_term"))]
+use termcolor::Color;
+
+#[cfg(all(feature = "termcolor", feature = "ansi_term"))]
+pub fn termcolor_to_ansiterm(color: &Color) -> Option<ansi_term::Color> {
+    match color {
+        Color::Black => Some(ansi_term::Color::Black),
+        Color::Red => Some(ansi_term::Color::Red),
+        Color::Green => Some(ansi_term::Color::Green),
+        Color::Yellow => Some(ansi_term::Color::Yellow),
+        Color::Blue => Some(ansi_term::Color::Blue),
+        Color::Magenta => Some(ansi_term::Color::Purple),
+        Color::Cyan => Some(ansi_term::Color::Cyan),
+        Color::White => Some(ansi_term::Color::White),
+        _ => None,
+    }
+}
 
 #[inline(always)]
 pub fn try_log<W>(config: &Config, record: &Record<'_>, write: &mut W) -> Result<(), Error>
@@ -63,11 +80,27 @@ pub fn write_level<W>(record: &Record<'_>, write: &mut W, config: &Config) -> Re
 where
     W: Write + Sized,
 {
-    match config.level_padding {
-        LevelPadding::Left => write!(write, "[{: >5}] ", record.level())?,
-        LevelPadding::Right => write!(write, "[{: <5}] ", record.level())?,
-        LevelPadding::Off => write!(write, "[{}] ", record.level())?,
+    #[cfg(all(feature = "termcolor", feature = "ansi_term"))]
+    let color = match &config.level_color[record.level() as usize] {
+        Some(termcolor) => termcolor_to_ansiterm(termcolor),
+        None => None,
     };
+
+    let level = match config.level_padding {
+        LevelPadding::Left => format!("[{: >5}]", record.level()),
+        LevelPadding::Right => format!("[{: <5}]", record.level()),
+        LevelPadding::Off => format!("[{}]", record.level()),
+    };
+
+    #[cfg(all(feature = "termcolor", feature = "ansi_term"))]
+    match color {
+        Some(c) => write!(write, "{} ", c.paint(level))?,
+        None => write!(write, "{} ", level)?,
+    };
+
+    #[cfg(not(feature = "ansi_term"))]
+    write!(write, "{} ", level)?;
+
     Ok(())
 }
 

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -139,12 +139,16 @@ impl TermLogger {
 
         if self.config.level <= record.level() && self.config.level != LevelFilter::Off {
             #[cfg(not(feature = "ansi_term"))]
-            term_lock.set_color(ColorSpec::new().set_fg(color))?;
+            if !self.config.write_log_enable_colors {
+                term_lock.set_color(ColorSpec::new().set_fg(color))?;
+            }
 
             write_level(record, term_lock, &self.config)?;
 
             #[cfg(not(feature = "ansi_term"))]
-            term_lock.reset()?;
+            if !self.config.write_log_enable_colors {
+                term_lock.reset()?;
+            }
         }
 
         if self.config.thread <= record.level() && self.config.thread != LevelFilter::Off {

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -5,7 +5,9 @@ use log::{
 };
 use std::io::{Error, Write};
 use std::sync::Mutex;
-use termcolor::{BufferedStandardStream, ColorChoice, ColorSpec, WriteColor};
+use termcolor::{BufferedStandardStream, ColorChoice};
+#[cfg(not(feature = "ansi_term"))]
+use termcolor::{ColorSpec, WriteColor};
 
 use super::logging::*;
 
@@ -128,6 +130,7 @@ impl TermLogger {
         record: &Record<'_>,
         term_lock: &mut BufferedStandardStream,
     ) -> Result<(), Error> {
+        #[cfg(not(feature = "ansi_term"))]
         let color = self.config.level_color[record.level() as usize];
 
         if self.config.time <= record.level() && self.config.time != LevelFilter::Off {
@@ -135,8 +138,12 @@ impl TermLogger {
         }
 
         if self.config.level <= record.level() && self.config.level != LevelFilter::Off {
+            #[cfg(not(feature = "ansi_term"))]
             term_lock.set_color(ColorSpec::new().set_fg(color))?;
+
             write_level(record, term_lock, &self.config)?;
+
+            #[cfg(not(feature = "ansi_term"))]
             term_lock.reset()?;
         }
 

--- a/src/paris_macros/mod.rs
+++ b/src/paris_macros/mod.rs
@@ -2,7 +2,7 @@
 ///
 /// Passed data uses a colorize_string formatter from a `paris` crate, so it can
 /// contains special tags for controlling ANSI colors and styles
-/// More info: https://docs.rs/paris/1.5.7/paris/formatter/fn.colorize_string.html
+/// More info: <https://docs.rs/paris/1.5.7/paris/formatter/fn.colorize_string.html>
 ///
 /// # Examples
 ///
@@ -29,7 +29,7 @@ macro_rules! info {
 ///
 /// Passed data uses a colorize_string formatter from a `paris` crate, so it can
 /// contains special tags for controlling ANSI colors and styles
-/// More info: https://docs.rs/paris/1.5.7/paris/formatter/fn.colorize_string.html
+/// More info: <https://docs.rs/paris/1.5.7/paris/formatter/fn.colorize_string.html>
 ///
 /// # Examples
 ///
@@ -55,7 +55,7 @@ macro_rules! debug {
 ///
 /// Passed data uses a colorize_string formatter from a `paris` crate, so it can
 /// contains special tags for controlling ANSI colors and styles
-/// More info: https://docs.rs/paris/1.5.7/paris/formatter/fn.colorize_string.html
+/// More info: <https://docs.rs/paris/1.5.7/paris/formatter/fn.colorize_string.html>
 ///
 /// # Examples
 ///
@@ -83,7 +83,7 @@ macro_rules! trace {
 ///
 /// Passed data uses a colorize_string formatter from a `paris` crate, so it can
 /// contains special tags for controlling ANSI colors and styles
-/// More info: https://docs.rs/paris/1.5.7/paris/formatter/fn.colorize_string.html
+/// More info: <https://docs.rs/paris/1.5.7/paris/formatter/fn.colorize_string.html>
 ///
 /// # Examples
 ///
@@ -108,7 +108,7 @@ macro_rules! warn {
 ///
 /// Passed data uses a colorize_string formatter from a `paris` crate, so it can
 /// contains special tags for controlling ANSI colors and styles
-/// More info: https://docs.rs/paris/1.5.7/paris/formatter/fn.colorize_string.html
+/// More info: <https://docs.rs/paris/1.5.7/paris/formatter/fn.colorize_string.html>
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This commit adds a possibility to color the log levels using an ansi_term
crate for this purpose.

The change was intended for WriteLogger in mind, but as this feature will
be configurable and put in generic logging code, then other loggers can
benefit as well (if desired).

This way one can easily create a logfile with a similar colored look
as it is printed real-time on a terminal/console.

Tip: To view such a logfile with colors using 'less' you can use:
less -R /path/to/logfile