### PR TITLE
Update paris crate and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplelog"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2018"
 authors = ["Drakulix <github@drakulix.de>"]
 description = "A simple and easy-to-use logging facility for Rust's log crate"
@@ -25,6 +25,6 @@ default = ["termcolor"]
 [dependencies]
 log = { version = "0.4.*", features = ["std"] }
 termcolor = { version = "1.1.*", optional = true }
-paris = { version = "1.5.8", optional = true }
+paris = { version = "~1.5", optional = true }
 ansi_term = { version = "0.12", optional = true }
 chrono = "0.4.1"


### PR DESCRIPTION
Hi
There was another parsing fix in paris crate. I think that using always the newest paris 1.5.x version will be better then always release new simplelog version after paris change...
This PR is doing this ....