### PR TITLE
fix the problem of macro hygiene when paris is enabled

### DIFF
--- a/examples/paris_demo/Cargo.toml
+++ b/examples/paris_demo/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "paris_demo"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+simplelog = { path = "../../", features = ["paris"] }

--- a/examples/paris_demo/src/main.rs
+++ b/examples/paris_demo/src/main.rs
@@ -1,0 +1,8 @@
+fn main() {
+    simplelog::TermLogger::init(simplelog::LevelFilter::Debug,
+                                simplelog::Config::default(),
+                                simplelog::TerminalMode::Mixed,
+                                simplelog::ColorChoice::Auto).expect("Failed to start simplelog");
+
+    simplelog::info!("I can write <b>bold</b> text or use tags to <red>color it</>");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,11 @@ use log::*;
 #[cfg(feature = "paris")]
 pub(crate) mod paris_macros;
 #[cfg(feature = "paris")]
-pub extern crate paris;
+#[doc(hidden)]
+pub mod __private {
+    pub use log;
+    pub use paris;
+}
 
 /// Trait to have a common interface to obtain the Level of Loggers
 ///

--- a/src/paris_macros/mod.rs
+++ b/src/paris_macros/mod.rs
@@ -21,7 +21,7 @@
 #[macro_export]
 macro_rules! info {
     ($($args:tt)+) => {
-        log::info!("{}", paris::formatter::colorize_string(format!($($args)*)));
+        $crate::__private::log::info!("{}", $crate::__private::paris::formatter::colorize_string(format!($($args)*)));
     };
 }
 
@@ -47,7 +47,7 @@ macro_rules! info {
 #[macro_export]
 macro_rules! debug {
     ($($args:tt)+) => {
-        log::debug!("{}", paris::formatter::colorize_string(format!($($args)*)));
+        $crate::__private::log::debug!("{}", $crate::__private::paris::formatter::colorize_string(format!($($args)*)));
     };
 }
 
@@ -75,7 +75,7 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! trace {
     ($($args:tt)+) => {
-        log::trace!("{}", paris::formatter::colorize_string(format!($($args)*)));
+        $crate::__private::log::trace!("{}", $crate::__private::paris::formatter::colorize_string(format!($($args)*)));
     };
 }
 
@@ -100,7 +100,7 @@ macro_rules! trace {
 #[macro_export]
 macro_rules! warn {
     ($($args:tt)+) => {
-        log::warn!("{}", paris::formatter::colorize_string(format!($($args)*)));
+        $crate::__private::log::warn!("{}", $crate::__private::paris::formatter::colorize_string(format!($($args)*)));
     };
 }
 
@@ -125,6 +125,6 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! error {
     ($($args:tt)+) => {
-        log::error!("{}", paris::formatter::colorize_string(format!($($args)*)));
+        $crate::__private::log::error!("{}", $crate::__private::paris::formatter::colorize_string(format!($($args)*)));
     };
 }


### PR DESCRIPTION
Please see: [Why should simplelog’s dependencies be introduced when its paris feature is enabled?](https://users.rust-lang.org/t/why-should-simplelogs-dependencies-be-introduced-when-its-paris-feature-is-enabled/72572)

Although [issue #91](https://github.com/Drakulix/simplelog.rs/issues/91) has been closed, this PR actually resolves it.