### PR TITLE
Make try_log public so that custom loggers can use it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub use self::config::{
 };
 #[cfg(feature = "test")]
 pub use self::loggers::TestLogger;
-pub use self::loggers::{CombinedLogger, SimpleLogger, WriteLogger};
+pub use self::loggers::{logging::try_log, CombinedLogger, SimpleLogger, WriteLogger};
 #[cfg(feature = "termcolor")]
 pub use self::loggers::{TermLogger, TerminalMode};
 #[cfg(feature = "termcolor")]


### PR DESCRIPTION
My use case that requires this change is:
From my DLL plugin I want to log to a file but also to the host, by sending it strings (one per log record).
I need to log each line separately to the host, but `Write` doesn't let me know when each record starts/ends.
So I need to log to a `String` (actually `Cursor<Vec<u8>>`, then `str::from_utf8`, then send the `String` to the host) and I need to be able to call `try_log` for that.