### PR TITLE
make chrono optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ termcolor = { version = "1.1.*", optional = true }
 paris = { version = "~1.5.12", optional = true }
 ansi_term = { version = "0.12", optional = true }
 time = { version = "0.3.7", features = ["formatting", "macros"] }
+chrono = { version = "0.4.26", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,12 @@
 mod config;
 mod loggers;
 
+#[cfg(feature = "chrono")]
+pub use self::config::{
+    Config, ConfigBuilder, LevelPadding, TargetPadding, ThreadLogMode, ThreadPadding,
+};
+
+#[cfg(not(feature = "chrono"))]
 pub use self::config::{
     format_description, Config, ConfigBuilder, FormatItem, LevelPadding, TargetPadding,
     ThreadLogMode, ThreadPadding,


### PR DESCRIPTION
This pull request is not ready to merge, is more for discussion.

Chrono has two new maintainer and in the last months there is continues developments on it. The segfault on localtime_r is fixed and there is more improvements.

The reason for make chrono optional again is, that many project rely on it, it has `set_time_to_local` and it has better formatting options then time.
