### PR TITLE
Remove newline from TestLogger time output

### DIFF
--- a/src/loggers/testlog.rs
+++ b/src/loggers/testlog.rs
@@ -137,7 +137,7 @@ pub fn write_time(config: &Config) {
         TimeFormat::Custom(format) => time.format(&format),
     };
     match res {
-        Ok(time) => println!("{} ", time),
+        Ok(time) => print!("{} ", time),
         Err(err) => panic!("Invalid time format: {}", err),
     };
 }


### PR DESCRIPTION
I noticed a `println!` where I would have expected a `print!` in the TestLogger's write_time function. This was causing log statements to be formatted as:

```
15:28:59
[INFO] [my_project/src/foo.rs:441] Finished Task 1
15:28:59
[INFO] [my_project/src/foo.rs:444] Processing 0 items for Task 2
15:29:01
[INFO] [my_project/src/bar.rs:482] 1 Total Result
```

With this change, TestLogger output looks like:

```
15:28:59 [INFO] [my_project/src/foo.rs:441] Finished Task 1
15:28:59 [INFO] [my_project/src/foo.rs:444] Processing 0 items for Task 2
15:29:01 [INFO] [my_project/src/bar.rs:482] 1 Total Result
```