### PR TITLE
The `new` method of loggers are now `#[must_use]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+ - The `new` method of loggers are now `#[must_use]` to prevent confusion when `new` is used called instead of `init`
 ## v0.12.0
  - Replaces the semingly unmainted chrono library with the time crate.
  - Addresses through this update 

--- a/src/loggers/comblog.rs
+++ b/src/loggers/comblog.rs
@@ -74,6 +74,7 @@ impl CombinedLogger {
     ///         );
     /// # }
     /// ```
+    #[must_use]
     pub fn new(logger: Vec<Box<dyn SharedLogger>>) -> Box<CombinedLogger> {
         let mut log_level = LevelFilter::Off;
         for log in &logger {

--- a/src/loggers/simplelog.rs
+++ b/src/loggers/simplelog.rs
@@ -56,6 +56,7 @@ impl SimpleLogger {
     /// let simple_logger = SimpleLogger::new(LevelFilter::Info, Config::default());
     /// # }
     /// ```
+    #[must_use]
     pub fn new(log_level: LevelFilter, config: Config) -> Box<SimpleLogger> {
         Box::new(SimpleLogger {
             level: log_level,

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -97,6 +97,7 @@ impl TermLogger {
     /// );
     /// # }
     /// ```
+    #[must_use]
     pub fn new(
         log_level: LevelFilter,
         config: Config,

--- a/src/loggers/testlog.rs
+++ b/src/loggers/testlog.rs
@@ -61,6 +61,7 @@ impl TestLogger {
     /// let test_logger = TestLogger::new(LevelFilter::Info, Config::default());
     /// # }
     /// ```
+    #[must_use]
     pub fn new(log_level: LevelFilter, config: Config) -> Box<TestLogger> {
         Box::new(TestLogger {
             level: log_level,

--- a/src/loggers/writelog.rs
+++ b/src/loggers/writelog.rs
@@ -56,6 +56,7 @@ impl<W: Write + Send + 'static> WriteLogger<W> {
     /// let file_logger = WriteLogger::new(LevelFilter::Info, Config::default(), File::create("my_rust_bin.log").unwrap());
     /// # }
     /// ```
+    #[must_use]
     pub fn new(log_level: LevelFilter, config: Config, writable: W) -> Box<WriteLogger<W>> {
         Box::new(WriteLogger {
             level: log_level,


### PR DESCRIPTION
The `new` method of loggers are now `#[must_use]` to prevent confusion when `new` is used called instead of `init`.  

Currently the following code will appear completely valid but silently not do any logging:

```rust
use log::*;
use simplelog::*;

fn main() {
    TermLogger::new(
        LevelFilter::Trace,
        Config::default(),
        TerminalMode::Stdout,
        ColorChoice::Auto,
    );
    error!("Red error");
    warn!("Yellow warning");
    info!("Blue info");
    debug!("Cyan debug");
    trace!("White trace");
}
```

With this change a compiler warning is generated on `new`.