### PR TITLE
add set_output_format_custom for Config.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@ use std::borrow::Cow;
 use termcolor::Color;
 pub use time::{format_description::FormatItem, macros::format_description, UtcOffset};
 
+use crate::format::*;
+
 #[derive(Debug, Clone, Copy)]
 /// Padding to be used for logging the level
 pub enum LevelPadding {
@@ -81,6 +83,7 @@ pub struct Config {
     pub(crate) location: LevelFilter,
     pub(crate) time_format: TimeFormat,
     pub(crate) time_offset: UtcOffset,
+    pub(crate) output_format: Format,
     pub(crate) filter_allow: Cow<'static, [Cow<'static, str>]>,
     pub(crate) filter_ignore: Cow<'static, [Cow<'static, str>]>,
     #[cfg(feature = "termcolor")]
@@ -300,6 +303,31 @@ impl ConfigBuilder {
         self
     }
 
+    /// Sets the output format to a custom representation.
+    ///
+    /// # Usage
+    ///
+    /// ```
+    /// use simplelog::ConfigBuilder;
+    /// use simplelog::FormatBuilder;
+    ///
+    /// let format = FormatBuilder::new()
+    ///     .time()
+    ///     .literal(" [")
+    ///     .level()
+    ///     .literal("] ")
+    ///     .args()
+    ///     .build();
+    ///
+    /// let config = ConfigBuilder::new()
+    ///     .set_output_format_custom(format)
+    ///     .build();
+    /// ```
+    pub fn set_output_format_custom(&mut self, output_format: Format) -> &mut ConfigBuilder {
+        self.0.output_format = output_format;
+        self
+    }
+
     /// Build new `Config`
     pub fn build(&mut self) -> Config {
         self.0.clone()
@@ -326,6 +354,7 @@ impl Default for Config {
             location: LevelFilter::Trace,
             time_format: TimeFormat::Custom(format_description!("[hour]:[minute]:[second]")),
             time_offset: UtcOffset::UTC,
+            output_format: Default::default(),
             filter_allow: Cow::Borrowed(&[]),
             filter_ignore: Cow::Borrowed(&[]),
             write_log_enable_colors: false,

--- a/src/format.rs
+++ b/src/format.rs
@@ -60,20 +60,29 @@ impl Format {
 
 impl Default for Format {
     fn default() -> Self {
+        // try to be consistent with the original format.
         FormatBuilder::new()
             .begin_time()
+            .filter_level(LevelFilter::Error)
             .wrap_space(true)
             .end()
             .literal("[")
             .level()
             .literal("]")
             .begin_thread()
+            .filter_level(LevelFilter::Debug)
             .wrap_space(true)
             .end()
-            .target()
-            .literal(": ")
+            .begin_target()
+            .filter_level(LevelFilter::Debug)
+            .end()
+            .begin_literal(": ")
+            .filter_level(LevelFilter::Debug)
+            .end()
             .literal("[")
-            .location()
+            .begin_location()
+            .filter_level(LevelFilter::Trace)
+            .end()
             .literal("]")
             .begin_args()
             .wrap_space(true)
@@ -266,7 +275,7 @@ impl FormatBuilder {
     /// {
     ///     use log::Level;
     ///     use termcolor::Color;
-    /// 
+    ///
     ///     builder.begin_level()
     ///         .level_color(Level::Error, Color::Red)
     ///         .level_color(Level::Warn, Color::Yellow)

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,9 +1,13 @@
 use std::vec::Vec;
 
 use log::Level;
+#[cfg(feature = "termcolor")]
+use termcolor::Color;
+
+use crate::LevelFilter;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) enum FormatPart {
+pub(crate) enum FormatPartType {
     Time,
     Level,
     Thread,
@@ -18,10 +22,32 @@ pub(crate) enum FormatPart {
     Literal(&'static str),
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct FormatPart {
+    pub(crate) part_type: FormatPartType,
+    pub(crate) wrap_space: bool,
+    pub(crate) level_filter: LevelFilter,
+    #[cfg(feature = "termcolor")]
+    pub(crate) level_color: [Option<Color>; 6],
+}
+
+impl FormatPart {
+    pub fn new(type_: FormatPartType) -> Self {
+        Self {
+            part_type: type_,
+            wrap_space: false,
+            // TODO: Confirm the default level.
+            level_filter: LevelFilter::Trace,
+            #[cfg(feature = "termcolor")]
+            level_color: [None; 6],
+        }
+    }
+}
+
 /// output format.
 #[derive(Clone, Debug)]
 pub struct Format {
-    pub(crate) format_parts: Vec<(Level, bool, FormatPart)>,
+    pub(crate) format_parts: Vec<FormatPart>,
 }
 
 impl Format {
@@ -35,17 +61,23 @@ impl Format {
 impl Default for Format {
     fn default() -> Self {
         FormatBuilder::new()
-            .time_with_level_and_wrap_space(Level::Trace)
+            .begin_time()
+            .wrap_space(true)
+            .end()
             .literal("[")
             .level()
             .literal("]")
-            .thread_with_level_and_wrap_space(Level::Trace)
+            .begin_thread()
+            .wrap_space(true)
+            .end()
             .target()
             .literal(": ")
             .literal("[")
             .location()
             .literal("]")
-            .args_with_level_and_wrap_space(Level::Trace)
+            .begin_args()
+            .wrap_space(true)
+            .end()
             .build()
     }
 }
@@ -53,10 +85,8 @@ impl Default for Format {
 /// output format builder.
 pub struct FormatBuilder {
     pub(crate) format: Format,
+    current_part: Option<FormatPart>,
 }
-
-use FormatPart as FP;
-use Level as LV;
 
 #[allow(dead_code)]
 impl FormatBuilder {
@@ -64,120 +94,276 @@ impl FormatBuilder {
     pub fn new() -> Self {
         Self {
             format: Format::new(),
+            current_part: None,
         }
     }
 
-    fn push(&mut self, level: Level, wrap_space: bool, part: FormatPart) -> &mut Self {
-        self.format.format_parts.push((level, wrap_space, part));
+    fn push_part(&mut self, part: FormatPart) {
+        self.format.format_parts.push(part)
+    }
+
+    /// Set whether the part wraps spaces.
+    ///
+    /// Can only be used between begin_xxx() and end().
+    ///
+    /// # Usage
+    ///
+    /// ```
+    /// use simplelog::FormatBuilder;
+    ///
+    /// let format = FormatBuilder::new()
+    ///     .begin_time()
+    ///     .wrap_space(true)
+    ///     .end()
+    ///     .args()
+    ///     .build();
+    /// ```
+    pub fn wrap_space(&mut self, wrap_space: bool) -> &mut Self {
+        if let Some(ref mut part) = self.current_part.as_mut() {
+            part.wrap_space = wrap_space;
+        } else {
+            // TODO: panic ?
+        }
+        self
+    }
+
+    /// Set the filter level for part.
+    ///
+    /// Can only be used between begin_xxx() and end().
+    ///
+    /// # Usage
+    ///
+    /// ```
+    /// use simplelog::FormatBuilder;
+    /// use simplelog::LevelFilter;
+    ///
+    /// let format = FormatBuilder::new()
+    ///     .begin_time()
+    ///     .filter_level(LevelFilter::Info)
+    ///     .end()
+    ///     .args()
+    ///     .build();
+    /// ```
+    pub fn filter_level(&mut self, level_filter: LevelFilter) -> &mut Self {
+        if let Some(ref mut part) = self.current_part.as_mut() {
+            part.level_filter = level_filter;
+        } else {
+            // TODO: panic ?
+        }
+        self
+    }
+
+    /// Set the color of the part at level
+    ///
+    /// Can only be used between begin_xxx() and end().
+    ///
+    /// # Usage
+    ///
+    /// ```
+    /// use simplelog::FormatBuilder;
+    /// use log::Level;
+    /// use termcolor::Color;
+    ///
+    /// let format = FormatBuilder::new()
+    ///     .begin_time()
+    ///     .level_color(Level::Error, Color::Red)
+    ///     .end()
+    ///     .args()
+    ///     .build();
+    /// ```
+    #[cfg(feature = "termcolor")]
+    pub fn level_color(&mut self, level: Level, color: Color) -> &mut Self {
+        if let Some(part) = self.current_part.as_mut() {
+            debug_assert!((level as usize) < part.level_color.len());
+            part.level_color[level as usize] = Some(color);
+        } else {
+            // TODO: panic ?
+        }
+        self
+    }
+
+    /// begin time part.
+    pub fn begin_time(&mut self) -> &mut Self {
+        self.current_part = Some(FormatPart::new(FormatPartType::Time));
+        self
+    }
+
+    /// begin level part.
+    pub fn begin_level(&mut self) -> &mut Self {
+        self.current_part = Some(FormatPart::new(FormatPartType::Level));
+        self
+    }
+
+    /// begin thread part.
+    pub fn begin_thread(&mut self) -> &mut Self {
+        self.current_part = Some(FormatPart::new(FormatPartType::Thread));
+        self
+    }
+
+    /// begin target part.
+    pub fn begin_target(&mut self) -> &mut Self {
+        self.current_part = Some(FormatPart::new(FormatPartType::Target));
+        self
+    }
+
+    /// begin location part.
+    pub fn begin_location(&mut self) -> &mut Self {
+        self.current_part = Some(FormatPart::new(FormatPartType::Location));
+        self
+    }
+
+    /// begin module path part.
+    pub fn begin_module_path(&mut self) -> &mut Self {
+        self.current_part = Some(FormatPart::new(FormatPartType::ModulePath));
+        self
+    }
+
+    /// begin args part.
+    pub fn begin_args(&mut self) -> &mut Self {
+        self.current_part = Some(FormatPart::new(FormatPartType::Args));
+        self
+    }
+
+    /// begin literal part.
+    pub fn begin_literal(&mut self, literal: &'static str) -> &mut Self {
+        self.current_part = Some(FormatPart::new(FormatPartType::Literal(literal)));
+        self
+    }
+
+    /// end part.
+    pub fn end(&mut self) -> &mut Self {
+        if let Some(part) = self.current_part.take() {
+            self.push_part(part)
+        } else {
+            // TODO: panic ?
+        }
         self
     }
 
     /// add time part.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # use simplelog::FormatBuilder;
+    /// # let mut builder = FormatBuilder::new();
+    /// builder.begin_time().end();
+    /// ```
     pub fn time(&mut self) -> &mut Self {
-        self.push(LV::Trace, false, FP::Time)
-    }
-    /// add time part.
-    pub fn time_with_level(&mut self, level: Level) -> &mut Self {
-        self.push(level, false, FP::Time)
-    }
-    /// add time part.
-    pub fn time_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
-        self.push(level, true, FP::Time)
+        self.begin_time().end()
     }
 
     /// add level part.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # use simplelog::FormatBuilder;
+    /// # let mut builder = FormatBuilder::new();
+    /// #[cfg(not(feature = "termcolor"))]
+    /// {
+    ///     builder.begin_level().end();
+    /// }
+    /// #[cfg(feature = "termcolor")]
+    /// {
+    ///     use log::Level;
+    ///     use termcolor::Color;
+    /// 
+    ///     builder.begin_level()
+    ///         .level_color(Level::Error, Color::Red)
+    ///         .level_color(Level::Warn, Color::Yellow)
+    ///         .level_color(Level::Info, Color::Blue)
+    ///         .level_color(Level::Debug, Color::Cyan)
+    ///         .level_color(Level::Trace, Color::White)
+    ///         .end();
+    /// }
+    /// ```
     pub fn level(&mut self) -> &mut Self {
-        self.push(LV::Trace, false, FP::Level)
-    }
-    /// add level part.
-    pub fn level_with_level(&mut self, level: Level) -> &mut Self {
-        self.push(level, false, FP::Level)
-    }
-    /// add level part.
-    pub fn level_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
-        self.push(level, true, FP::Level)
+        #[cfg(feature = "termcolor")]
+        {
+            self.begin_level()
+                .level_color(Level::Error, Color::Red)
+                .level_color(Level::Warn, Color::Yellow)
+                .level_color(Level::Info, Color::Blue)
+                .level_color(Level::Debug, Color::Cyan)
+                .level_color(Level::Trace, Color::White)
+                .end()
+        }
+        #[cfg(not(feature = "termcolor"))]
+        {
+            self.begin_level().end()
+        }
     }
 
     /// add thread part.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # use simplelog::FormatBuilder;
+    /// # let mut builder = FormatBuilder::new();
+    /// builder.begin_thread().end();
+    /// ```
     pub fn thread(&mut self) -> &mut Self {
-        self.push(LV::Trace, false, FP::Thread)
-    }
-    /// add thread part.
-    pub fn thread_with_level(&mut self, level: Level) -> &mut Self {
-        self.push(level, false, FP::Thread)
-    }
-    /// add thread part.
-    pub fn thread_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
-        self.push(level, true, FP::Thread)
+        self.begin_thread().end()
     }
 
     /// add target part.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # use simplelog::FormatBuilder;
+    /// # let mut builder = FormatBuilder::new();
+    /// builder.begin_target().end();
+    /// ```
     pub fn target(&mut self) -> &mut Self {
-        self.push(LV::Trace, false, FP::Target)
-    }
-    /// add target part.
-    pub fn target_with_level(&mut self, level: Level) -> &mut Self {
-        self.push(level, false, FP::Target)
-    }
-    /// add target part.
-    pub fn target_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
-        self.push(level, true, FP::Target)
+        self.begin_target().end()
     }
 
     /// add location  part.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # use simplelog::FormatBuilder;
+    /// # let mut builder = FormatBuilder::new();
+    /// builder.begin_location().end();
+    /// ```
     pub fn location(&mut self) -> &mut Self {
-        self.push(LV::Trace, false, FP::Location)
-    }
-    /// add location  part.
-    pub fn location_with_level(&mut self, level: Level) -> &mut Self {
-        self.push(level, false, FP::Location)
-    }
-    /// add location  part.
-    pub fn location_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
-        self.push(level, true, FP::Location)
+        self.begin_location().end()
     }
 
     /// add module path part.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # use simplelog::FormatBuilder;
+    /// # let mut builder = FormatBuilder::new();
+    /// builder.begin_module_path().end();
+    /// ```
     pub fn module_path(&mut self) -> &mut Self {
-        self.push(LV::Trace, false, FP::ModulePath)
-    }
-    /// add module path part.
-    pub fn module_path_with_level(&mut self, level: Level) -> &mut Self {
-        self.push(level, false, FP::ModulePath)
-    }
-    /// add module path part.
-    pub fn module_path_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
-        self.push(level, true, FP::ModulePath)
+        self.begin_module_path().end()
     }
 
     /// add args part.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # use simplelog::FormatBuilder;
+    /// # let mut builder = FormatBuilder::new();
+    /// builder.begin_args().end();
+    /// ```
     pub fn args(&mut self) -> &mut Self {
-        self.push(LV::Trace, false, FP::Args)
-    }
-    /// add args part.
-    pub fn args_with_level(&mut self, level: Level) -> &mut Self {
-        self.push(level, false, FP::Args)
-    }
-    /// add args part.
-    pub fn args_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
-        self.push(level, true, FP::Args)
+        self.begin_args().end()
     }
 
     /// add literal part.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # use simplelog::FormatBuilder;
+    /// # let mut builder = FormatBuilder::new();
+    /// # let literal = "literal";
+    /// builder.begin_literal(literal).end();
+    /// ```
     pub fn literal(&mut self, literal: &'static str) -> &mut Self {
-        self.push(LV::Trace, false, FP::Literal(literal))
-    }
-    /// add literal part.
-    pub fn literal_with_level(&mut self, level: Level, literal: &'static str) -> &mut Self {
-        self.push(level, false, FP::Literal(literal))
-    }
-    /// add literal part.
-    pub fn literal_with_level_and_wrap_space(
-        &mut self,
-        level: Level,
-        literal: &'static str,
-    ) -> &mut Self {
-        self.push(level, true, FP::Literal(literal))
+        self.begin_literal(literal).end()
     }
 
     /// build.

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,187 @@
+use std::vec::Vec;
+
+use log::Level;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum FormatPart {
+    Time,
+    Level,
+    Thread,
+    // ThreadId,
+    // ThreadName,
+    Target,
+    // File,
+    // Line,
+    Location,
+    ModulePath,
+    Args,
+    Literal(&'static str),
+}
+
+/// output format.
+#[derive(Clone, Debug)]
+pub struct Format {
+    pub(crate) format_parts: Vec<(Level, bool, FormatPart)>,
+}
+
+impl Format {
+    fn new() -> Self {
+        Self {
+            format_parts: Vec::new(),
+        }
+    }
+}
+
+impl Default for Format {
+    fn default() -> Self {
+        FormatBuilder::new()
+            .time_with_level_and_wrap_space(Level::Trace)
+            .literal("[")
+            .level()
+            .literal("]")
+            .thread_with_level_and_wrap_space(Level::Trace)
+            .target()
+            .literal(": ")
+            .literal("[")
+            .location()
+            .literal("]")
+            .args_with_level_and_wrap_space(Level::Trace)
+            .build()
+    }
+}
+
+/// output format builder.
+pub struct FormatBuilder {
+    pub(crate) format: Format,
+}
+
+use FormatPart as FP;
+use Level as LV;
+
+#[allow(dead_code)]
+impl FormatBuilder {
+    /// new builder.
+    pub fn new() -> Self {
+        Self {
+            format: Format::new(),
+        }
+    }
+
+    fn push(&mut self, level: Level, wrap_space: bool, part: FormatPart) -> &mut Self {
+        self.format.format_parts.push((level, wrap_space, part));
+        self
+    }
+
+    /// add time part.
+    pub fn time(&mut self) -> &mut Self {
+        self.push(LV::Trace, false, FP::Time)
+    }
+    /// add time part.
+    pub fn time_with_level(&mut self, level: Level) -> &mut Self {
+        self.push(level, false, FP::Time)
+    }
+    /// add time part.
+    pub fn time_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
+        self.push(level, true, FP::Time)
+    }
+
+    /// add level part.
+    pub fn level(&mut self) -> &mut Self {
+        self.push(LV::Trace, false, FP::Level)
+    }
+    /// add level part.
+    pub fn level_with_level(&mut self, level: Level) -> &mut Self {
+        self.push(level, false, FP::Level)
+    }
+    /// add level part.
+    pub fn level_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
+        self.push(level, true, FP::Level)
+    }
+
+    /// add thread part.
+    pub fn thread(&mut self) -> &mut Self {
+        self.push(LV::Trace, false, FP::Thread)
+    }
+    /// add thread part.
+    pub fn thread_with_level(&mut self, level: Level) -> &mut Self {
+        self.push(level, false, FP::Thread)
+    }
+    /// add thread part.
+    pub fn thread_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
+        self.push(level, true, FP::Thread)
+    }
+
+    /// add target part.
+    pub fn target(&mut self) -> &mut Self {
+        self.push(LV::Trace, false, FP::Target)
+    }
+    /// add target part.
+    pub fn target_with_level(&mut self, level: Level) -> &mut Self {
+        self.push(level, false, FP::Target)
+    }
+    /// add target part.
+    pub fn target_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
+        self.push(level, true, FP::Target)
+    }
+
+    /// add location  part.
+    pub fn location(&mut self) -> &mut Self {
+        self.push(LV::Trace, false, FP::Location)
+    }
+    /// add location  part.
+    pub fn location_with_level(&mut self, level: Level) -> &mut Self {
+        self.push(level, false, FP::Location)
+    }
+    /// add location  part.
+    pub fn location_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
+        self.push(level, true, FP::Location)
+    }
+
+    /// add module path part.
+    pub fn module_path(&mut self) -> &mut Self {
+        self.push(LV::Trace, false, FP::ModulePath)
+    }
+    /// add module path part.
+    pub fn module_path_with_level(&mut self, level: Level) -> &mut Self {
+        self.push(level, false, FP::ModulePath)
+    }
+    /// add module path part.
+    pub fn module_path_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
+        self.push(level, true, FP::ModulePath)
+    }
+
+    /// add args part.
+    pub fn args(&mut self) -> &mut Self {
+        self.push(LV::Trace, false, FP::Args)
+    }
+    /// add args part.
+    pub fn args_with_level(&mut self, level: Level) -> &mut Self {
+        self.push(level, false, FP::Args)
+    }
+    /// add args part.
+    pub fn args_with_level_and_wrap_space(&mut self, level: Level) -> &mut Self {
+        self.push(level, true, FP::Args)
+    }
+
+    /// add literal part.
+    pub fn literal(&mut self, literal: &'static str) -> &mut Self {
+        self.push(LV::Trace, false, FP::Literal(literal))
+    }
+    /// add literal part.
+    pub fn literal_with_level(&mut self, level: Level, literal: &'static str) -> &mut Self {
+        self.push(level, false, FP::Literal(literal))
+    }
+    /// add literal part.
+    pub fn literal_with_level_and_wrap_space(
+        &mut self,
+        level: Level,
+        literal: &'static str,
+    ) -> &mut Self {
+        self.push(level, true, FP::Literal(literal))
+    }
+
+    /// build.
+    pub fn build(&self) -> Format {
+        self.format.clone()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 
 #![deny(missing_docs, rust_2018_idioms)]
 
+mod format;
 mod config;
 mod loggers;
 
@@ -28,6 +29,8 @@ pub use self::config::{
     format_description, Config, ConfigBuilder, FormatItem, LevelPadding, TargetPadding,
     ThreadLogMode, ThreadPadding,
 };
+pub use self::format::Format;
+pub use self::format::FormatBuilder;
 #[cfg(feature = "test")]
 pub use self::loggers::TestLogger;
 pub use self::loggers::{CombinedLogger, SimpleLogger, WriteLogger};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@
 
 #![deny(missing_docs, rust_2018_idioms)]
 
-mod format;
 mod config;
+mod format;
 mod loggers;
 
 pub use self::config::{

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -39,31 +39,31 @@ where
     }
 
     let (mut have_space, parts) = if config.output_format.format_parts.len() >= 2 {
-        let (level, wrap_space, part) = config.output_format.format_parts[0];
-        if record.level() <= level {
+        let part = &config.output_format.format_parts[0];
+        if record.level() <= part.level_filter {
             write_part(
                 record,
                 write,
                 config,
-                part,
+                &part,
                 &mut set_color,
                 &mut reset_color,
             )?;
         }
-        if wrap_space {
+        if part.wrap_space {
             write!(write, " ")?;
         }
-        (wrap_space, &config.output_format.format_parts[1..])
+        (part.wrap_space, &config.output_format.format_parts[1..])
     } else {
         (false, &config.output_format.format_parts[..])
     };
 
-    for (level, wrap_space, part) in parts {
-        if record.level() > *level {
+    for part in parts {
+        if record.level() > part.level_filter {
             continue;
         }
 
-        if *wrap_space && !have_space {
+        if part.wrap_space && !have_space {
             write!(write, " ")?;
         }
 
@@ -71,12 +71,12 @@ where
             record,
             write,
             config,
-            *part,
+            part,
             &mut set_color,
             &mut reset_color,
         )?;
 
-        if *wrap_space {
+        if part.wrap_space {
             write!(write, " ")?;
             have_space = true;
         } else {
@@ -94,7 +94,7 @@ fn write_part<W, SF, RF>(
     record: &Record<'_>,
     write: &mut W,
     config: &Config,
-    part: FormatPart,
+    part: &FormatPart,
     mut set_color: SF,
     mut reset_color: RF,
 ) -> Result<(), Error>
@@ -103,9 +103,9 @@ where
     SF: FnMut(&mut W) -> Result<(), Error>,
     RF: FnMut(&mut W) -> Result<(), Error>,
 {
-    use FormatPart as FP;
+    use crate::format::FormatPartType as FP;
 
-    match part {
+    match part.part_type {
         FP::Time if config.time <= record.level() && config.time != LevelFilter::Off => {
             write_time(write, config)?;
         }

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -22,46 +22,132 @@ pub fn termcolor_to_ansiterm(color: &Color) -> Option<ansi_term::Color> {
 }
 
 #[inline(always)]
-pub fn try_log<W>(config: &Config, record: &Record<'_>, write: &mut W) -> Result<(), Error>
+pub fn try_log<W, SF, RF>(
+    config: &Config,
+    record: &Record<'_>,
+    write: &mut W,
+    mut set_color: SF,
+    mut reset_color: RF,
+) -> Result<(), Error>
 where
     W: Write + Sized,
+    SF: FnMut(&mut W) -> Result<(), Error>,
+    RF: FnMut(&mut W) -> Result<(), Error>,
 {
     if should_skip(config, record) {
         return Ok(());
     }
 
-    if config.time <= record.level() && config.time != LevelFilter::Off {
-        write_time(write, config)?;
-    }
+    let (mut have_space, parts) = if config.output_format.format_parts.len() >= 2 {
+        let (level, wrap_space, part) = config.output_format.format_parts[0];
+        if record.level() <= level {
+            write_part(
+                record,
+                write,
+                config,
+                part,
+                &mut set_color,
+                &mut reset_color,
+            )?;
+        }
+        if wrap_space {
+            write!(write, " ")?;
+        }
+        (wrap_space, &config.output_format.format_parts[1..])
+    } else {
+        (false, &config.output_format.format_parts[..])
+    };
 
-    if config.level <= record.level() && config.level != LevelFilter::Off {
-        write_level(record, write, config)?;
-    }
+    for (level, wrap_space, part) in parts {
+        if record.level() > *level {
+            continue;
+        }
 
-    if config.thread <= record.level() && config.thread != LevelFilter::Off {
-        match config.thread_log_mode {
-            ThreadLogMode::IDs => {
-                write_thread_id(write, config)?;
-            }
-            ThreadLogMode::Names | ThreadLogMode::Both => {
-                write_thread_name(write, config)?;
-            }
+        if *wrap_space && !have_space {
+            write!(write, " ")?;
+        }
+
+        write_part(
+            record,
+            write,
+            config,
+            *part,
+            &mut set_color,
+            &mut reset_color,
+        )?;
+
+        if *wrap_space {
+            write!(write, " ")?;
+            have_space = true;
+        } else {
+            have_space = false;
         }
     }
 
-    if config.target <= record.level() && config.target != LevelFilter::Off {
-        write_target(record, write, config)?;
+    Ok(())
+}
+
+use crate::format::FormatPart;
+
+#[inline(always)]
+fn write_part<W, SF, RF>(
+    record: &Record<'_>,
+    write: &mut W,
+    config: &Config,
+    part: FormatPart,
+    mut set_color: SF,
+    mut reset_color: RF,
+) -> Result<(), Error>
+where
+    W: Write + Sized,
+    SF: FnMut(&mut W) -> Result<(), Error>,
+    RF: FnMut(&mut W) -> Result<(), Error>,
+{
+    use FormatPart as FP;
+
+    match part {
+        FP::Time if config.time <= record.level() && config.time != LevelFilter::Off => {
+            write_time(write, config)?;
+        }
+        FP::Level if config.level <= record.level() && config.level != LevelFilter::Off => {
+            set_color(write)?;
+            match write_level(record, write, config) {
+                Ok(()) => reset_color(write)?,
+                Err(e) => {
+                    reset_color(write)?;
+                    return Err(e);
+                }
+            };
+        }
+        FP::Thread if config.thread <= record.level() && config.thread != LevelFilter::Off => {
+            match config.thread_log_mode {
+                ThreadLogMode::IDs => {
+                    write_thread_id(write, config)?;
+                }
+                ThreadLogMode::Names | ThreadLogMode::Both => {
+                    write_thread_name(write, config)?;
+                }
+            }
+        }
+        FP::Target if config.target <= record.level() && config.target != LevelFilter::Off => {
+            write_target(record, write, config)?
+        }
+        FP::Location
+            if config.location <= record.level() && config.location != LevelFilter::Off =>
+        {
+            write_location(record, write)?;
+        }
+        FP::ModulePath => write_module_path(record, write)?,
+        FP::Args => write_args(record, write)?,
+        FP::Literal(literal) => write!(write, "{}", literal)?,
+        _ => (),
     }
 
-    if config.location <= record.level() && config.location != LevelFilter::Off {
-        write_location(record, write)?;
-    }
-
-    write_args(record, write)
+    Ok(())
 }
 
 #[inline(always)]
-pub fn write_time<W>(write: &mut W, config: &Config) -> Result<(), Error>
+fn write_time<W>(write: &mut W, config: &Config) -> Result<(), Error>
 where
     W: Write + Sized,
 {
@@ -80,12 +166,12 @@ where
         _ => {}
     };
 
-    write!(write, " ")?;
+    // write!(write, " ")?;
     Ok(())
 }
 
 #[inline(always)]
-pub fn write_level<W>(record: &Record<'_>, write: &mut W, config: &Config) -> Result<(), Error>
+fn write_level<W>(record: &Record<'_>, write: &mut W, config: &Config) -> Result<(), Error>
 where
     W: Write + Sized,
 {
@@ -102,48 +188,38 @@ where
     };
 
     let level = match config.level_padding {
-        LevelPadding::Left => format!("[{: >5}]", record.level()),
-        LevelPadding::Right => format!("[{: <5}]", record.level()),
-        LevelPadding::Off => format!("[{}]", record.level()),
+        LevelPadding::Left => format!("{: >5}", record.level()),
+        LevelPadding::Right => format!("{: <5}", record.level()),
+        LevelPadding::Off => format!("{}", record.level()),
     };
 
     #[cfg(all(feature = "termcolor", feature = "ansi_term"))]
     match color {
-        Some(c) => write!(write, "{} ", c.paint(level))?,
-        None => write!(write, "{} ", level)?,
+        Some(c) => write!(write, "{}", c.paint(level))?,
+        None => write!(write, "{}", level)?,
     };
 
     #[cfg(not(feature = "ansi_term"))]
-    write!(write, "{} ", level)?;
+    write!(write, "{}", level)?;
 
     Ok(())
 }
 
 #[inline(always)]
-pub fn write_target<W>(record: &Record<'_>, write: &mut W, config: &Config) -> Result<(), Error>
+fn write_target<W>(record: &Record<'_>, write: &mut W, config: &Config) -> Result<(), Error>
 where
     W: Write + Sized,
 {
     // dbg!(&config.target_padding);
     match config.target_padding {
         TargetPadding::Left(pad) => {
-            write!(
-                write,
-                "{target:>pad$}: ",
-                pad = pad,
-                target = record.target()
-            )?;
+            write!(write, "{target:>pad$}", pad = pad, target = record.target())?;
         }
         TargetPadding::Right(pad) => {
-            write!(
-                write,
-                "{target:<pad$}: ",
-                pad = pad,
-                target = record.target()
-            )?;
+            write!(write, "{target:<pad$}", pad = pad, target = record.target())?;
         }
         TargetPadding::Off => {
-            write!(write, "{}: ", record.target())?;
+            write!(write, "{}", record.target())?;
         }
     }
 
@@ -151,33 +227,33 @@ where
 }
 
 #[inline(always)]
-pub fn write_location<W>(record: &Record<'_>, write: &mut W) -> Result<(), Error>
+fn write_location<W>(record: &Record<'_>, write: &mut W) -> Result<(), Error>
 where
     W: Write + Sized,
 {
     let file = record.file().unwrap_or("<unknown>");
     if let Some(line) = record.line() {
-        write!(write, "[{}:{}] ", file, line)?;
+        write!(write, "{}:{}", file, line)?;
     } else {
-        write!(write, "[{}:<unknown>] ", file)?;
+        write!(write, "{}:<unknown>", file)?;
     }
     Ok(())
 }
 
-pub fn write_thread_name<W>(write: &mut W, config: &Config) -> Result<(), Error>
+fn write_thread_name<W>(write: &mut W, config: &Config) -> Result<(), Error>
 where
     W: Write + Sized,
 {
     if let Some(name) = thread::current().name() {
         match config.thread_padding {
             ThreadPadding::Left { 0: qty } => {
-                write!(write, "({name:>0$}) ", qty, name = name)?;
+                write!(write, "({name:>0$})", qty, name = name)?;
             }
             ThreadPadding::Right { 0: qty } => {
-                write!(write, "({name:<0$}) ", qty, name = name)?;
+                write!(write, "({name:<0$})", qty, name = name)?;
             }
             ThreadPadding::Off => {
-                write!(write, "({}) ", name)?;
+                write!(write, "({})", name)?;
             }
         }
     } else if config.thread_log_mode == ThreadLogMode::Both {
@@ -187,7 +263,7 @@ where
     Ok(())
 }
 
-pub fn write_thread_id<W>(write: &mut W, config: &Config) -> Result<(), Error>
+fn write_thread_id<W>(write: &mut W, config: &Config) -> Result<(), Error>
 where
     W: Write + Sized,
 {
@@ -196,20 +272,29 @@ where
     let id = id.replace(")", "");
     match config.thread_padding {
         ThreadPadding::Left { 0: qty } => {
-            write!(write, "({id:>0$}) ", qty, id = id)?;
+            write!(write, "({id:>0$} ", qty, id = id)?;
         }
         ThreadPadding::Right { 0: qty } => {
-            write!(write, "({id:<0$}) ", qty, id = id)?;
+            write!(write, "({id:<0$})", qty, id = id)?;
         }
         ThreadPadding::Off => {
-            write!(write, "({}) ", id)?;
+            write!(write, "({})", id)?;
         }
     }
     Ok(())
 }
 
 #[inline(always)]
-pub fn write_args<W>(record: &Record<'_>, write: &mut W) -> Result<(), Error>
+fn write_module_path<W>(record: &Record<'_>, write: &mut W) -> Result<(), Error>
+where
+    W: Write + Sized,
+{
+    writeln!(write, "{}", record.module_path().unwrap_or("<unknown>"))?;
+    Ok(())
+}
+
+#[inline(always)]
+fn write_args<W>(record: &Record<'_>, write: &mut W) -> Result<(), Error>
 where
     W: Write + Sized,
 {

--- a/src/loggers/simplelog.rs
+++ b/src/loggers/simplelog.rs
@@ -83,8 +83,8 @@ impl Log for SimpleLogger {
                         &self.config,
                         record,
                         &mut stderr_lock,
-                        |_| Ok(()),
-                        |_| Ok(()),
+                        |_, _, _| Ok(()),
+                        |_, _, _| Ok(()),
                     );
                 }
                 _ => {
@@ -94,8 +94,8 @@ impl Log for SimpleLogger {
                         &self.config,
                         record,
                         &mut stdout_lock,
-                        |_| Ok(()),
-                        |_| Ok(()),
+                        |_, _, _| Ok(()),
+                        |_, _, _| Ok(()),
                     );
                 }
             }

--- a/src/loggers/simplelog.rs
+++ b/src/loggers/simplelog.rs
@@ -79,12 +79,24 @@ impl Log for SimpleLogger {
                 Level::Error => {
                     let stderr = stderr();
                     let mut stderr_lock = stderr.lock();
-                    let _ = try_log(&self.config, record, &mut stderr_lock);
+                    let _ = try_log(
+                        &self.config,
+                        record,
+                        &mut stderr_lock,
+                        |_| Ok(()),
+                        |_| Ok(()),
+                    );
                 }
                 _ => {
                     let stdout = stdout();
                     let mut stdout_lock = stdout.lock();
-                    let _ = try_log(&self.config, record, &mut stdout_lock);
+                    let _ = try_log(
+                        &self.config,
+                        record,
+                        &mut stdout_lock,
+                        |_| Ok(()),
+                        |_| Ok(()),
+                    );
                 }
             }
         }

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -189,16 +189,25 @@ impl TermLogger {
 
             let mut streams = self.streams.lock().unwrap();
 
-            #[cfg(not(feature = "ansi_term"))]
-            let color = self.config.level_color[record.level() as usize];
-            let set_color = |term_lock: &mut BufferedStandardStream| -> Result<(), Error> {
+            use crate::format::FormatPart;
+
+            // #[cfg(not(feature = "ansi_term"))]
+            // let color = self.config.level_color[record.level() as usize];
+            let set_color = |term_lock: &mut BufferedStandardStream,
+                             level: Level,
+                             part: &FormatPart|
+             -> Result<(), Error> {
                 #[cfg(not(feature = "ansi_term"))]
                 if !self.config.write_log_enable_colors {
-                    term_lock.set_color(ColorSpec::new().set_fg(color))?;
+                    term_lock
+                        .set_color(ColorSpec::new().set_fg(part.level_color[level as usize]))?;
                 }
                 Ok(())
             };
-            let reset_color = |term_lock: &mut BufferedStandardStream| -> Result<(), Error> {
+            let reset_color = |term_lock: &mut BufferedStandardStream,
+                               _level: Level,
+                               _part: &FormatPart|
+             -> Result<(), Error> {
                 #[cfg(not(feature = "ansi_term"))]
                 if !self.config.write_log_enable_colors {
                     term_lock.reset()?;

--- a/src/loggers/writelog.rs
+++ b/src/loggers/writelog.rs
@@ -74,7 +74,13 @@ impl<W: Write + Send + 'static> Log for WriteLogger<W> {
     fn log(&self, record: &Record<'_>) {
         if self.enabled(record.metadata()) {
             let mut write_lock = self.writable.lock().unwrap();
-            let _ = try_log(&self.config, record, &mut *write_lock);
+            let _ = try_log(
+                &self.config,
+                record,
+                &mut *write_lock,
+                |_| Ok(()),
+                |_| Ok(()),
+            );
         }
     }
 

--- a/src/loggers/writelog.rs
+++ b/src/loggers/writelog.rs
@@ -78,8 +78,8 @@ impl<W: Write + Send + 'static> Log for WriteLogger<W> {
                 &self.config,
                 record,
                 &mut *write_lock,
-                |_| Ok(()),
-                |_| Ok(()),
+                |_, _, _| Ok(()),
+                |_, _, _| Ok(()),
             );
         }
     }


### PR DESCRIPTION
Create a custom Format through the FormatBuilder,
```rust
let format : Format = FormatBuilder::new()
    .time_with_level_and_wrap_space(Level::Trace)
    .literal("[")
    .level()
    .literal("]")
    .thread_with_level_and_wrap_space(Level::Trace)
    .target()
    .literal(": ")
    .literal("[")
    .location()
    .literal("]")
    .args_with_level_and_wrap_space(Level::Trace)
    .build();

let config = ConfigBuilder::new()
    .set_output_format_custom(format)
    .build();
```
This will create a format similar to the original, starting with the time, followed by a level wrapped in square brackets, and so on.
The xxx_with_level_and_wrap_space series API maintains a space between the modified fragment and other fragments, while there is only one space between two xxx_with_level_and_wrap_space. The parameter represents the level that can be output, similar to the original set_time_level.
Consider removing set_time_level and so on ?.
Currently, these APIs are not designed very well, but I want to discuss the feasibility of this solution.