### PR TITLE
Fix warnings in `cargo doc` from invalid link

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -187,7 +187,7 @@ impl ConfigBuilder {
     /// The easiest way to satisfy the static lifetime of the argument is to directly use the
     /// re-exported [`time::macros::format_description`] macro.
     ///
-    /// *Note*: The default time format is "[hour]:[minute]:[second]".
+    /// *Note*: The default time format is `[hour]:[minute]:[second]`.
     ///
     /// The syntax for the format_description macro can be found in the
     /// [`time` crate book](https://time-rs.github.io/book/api/format-description.html).


### PR DESCRIPTION
This just changes a doc comment to use backticks to wrap an format string rather than double quotes. Elsewhere in the crate format strings are wrapped in bacckticks in doc comments, so this seemed like the most consistent solution.

---

I noticed these coming up in PR diffs and figured it was an easy fix.