### PR TITLE
add `TimePadding` with `Right` and `AddZeros`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,17 @@ pub(crate) enum TimeFormat {
     Custom(&'static [time::format_description::FormatItem<'static>]),
 }
 
+#[derive(Debug, Clone, Copy)]
+/// Padding to be used for logging the time
+pub enum TimePadding {
+    /// Add spaces on the right side, up to usize many
+    Right(usize),
+    /// Do not pad the time
+    Off,
+    /// If appliciable, add zeros to the subseconds
+    AddZeros
+}
+
 /// Configuration for the Loggers
 ///
 /// All loggers print the message in the following form:
@@ -82,6 +93,7 @@ pub struct Config {
     pub(crate) module: LevelFilter,
     pub(crate) time_format: TimeFormat,
     pub(crate) time_offset: UtcOffset,
+    pub(crate) time_padding: TimePadding,
     pub(crate) filter_allow: Cow<'static, [Cow<'static, str>]>,
     pub(crate) filter_ignore: Cow<'static, [Cow<'static, str>]>,
     #[cfg(feature = "termcolor")]
@@ -226,6 +238,12 @@ impl ConfigBuilder {
         self
     }
 
+    /// Set how the time should be padded
+    pub fn set_time_padding(&mut self, padding: TimePadding) -> &mut ConfigBuilder {
+        self.0.time_padding = padding;
+        self
+    }
+
     /// Sets the offset used to the current local time offset
     /// (overriding values previously set by [`ConfigBuilder::set_time_offset`]).
     ///
@@ -345,6 +363,7 @@ impl Default for Config {
             module: LevelFilter::Off,
             time_format: TimeFormat::Custom(format_description!("[hour]:[minute]:[second]")),
             time_offset: UtcOffset::UTC,
+            time_padding: TimePadding::AddZeros,
             filter_allow: Cow::Borrowed(&[]),
             filter_ignore: Cow::Borrowed(&[]),
             write_log_enable_colors: false,


### PR DESCRIPTION
This is a proposed fix for #133.

I added a `TimePadding` Enum. in `write_time`, the formatted time stamp is generated with the `time` module like before, then I do some formatting.

- `TimePadding::Right` just applys an offset to the timestamp, like other paddings.
- `TimePadding::AddZeros` adds zeros to the Timestamp, accodring to it's length. (only with rfc3339 formatting)

## Usage
Build a `Config` like this:
```rs
                let conf = conf_builder
                    .set_location_level(elem)
                    .set_target_level(elem)
                    .set_max_level(elem)
                    .set_time_level(elem)
                    .set_time_format_rfc3339()
                    .set_time_padding(config::TimePadding::AddZeros)
                    .build();
```

Example output:
```txt
2023-08-02T08:08:45.217511363Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217519856Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217590429Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217599035Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217624283Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217628916Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217652289Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217656130Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217680170Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217684238Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217714112Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217717736Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217741200Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217782376Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217815202Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217819815Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217886072Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
2023-08-02T08:08:45.217891502Z [INFO] simplelog::tests: [src/lib.rs:238] Test Information
```


Note: This is my first Pull Request, I hope I didn't miss anything important.