### PR TITLE
add dependabot for dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
helping keep deps updated by config dependabot. set to weekly to avoid possible noise.