### PR TITLE
Add builder() associated function to Config to make a ConfigBuilder

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -91,6 +91,13 @@ pub struct Config {
     pub(crate) enable_paris_formatting: bool,
 }
 
+impl Config {
+    /// Create a new default `ConfigBuilder`
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::new()
+    }
+}
+
 /// Builder for the Logger Configurations (`Config`)
 ///
 /// All loggers print the message in the following form:


### PR DESCRIPTION
This makes the builder easier to access, without needing to import ConfigBuilder