### PR TITLE
Add config option for line endings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 
 [features]
 test = []
-crlf-line-endings = []
+
 default = ["termcolor", "local-offset"]
 local-offset = ["time/local-offset"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ include = [
 
 [features]
 test = []
-
 default = ["termcolor", "local-offset"]
 local-offset = ["time/local-offset"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 
 [features]
 test = []
+crlf-line-endings = []
 default = ["termcolor", "local-offset"]
 local-offset = ["time/local-offset"]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,13 +65,13 @@ pub enum LineEnding {
     /// Carriage return
     CR,
     /// Carriage return + Line feed
-    CRLF,
+    Crlf,
     /// Vertical tab
     VT,
     /// Form feed
     FF,
     /// Next line
-    NEL,
+    Nel,
     /// Line separator
     LS,
     /// Paragraph separator
@@ -142,14 +142,15 @@ impl ConfigBuilder {
         ConfigBuilder(Config::default())
     }
 
+    /// Set a custom line ending
     pub fn set_line_ending(&mut self, line_ending: LineEnding) -> &mut ConfigBuilder {
         match line_ending {
             LineEnding::LF => self.0.line_ending = String::from("\u{000A}"),
             LineEnding::CR => self.0.line_ending = String::from("\u{000D}"),
-            LineEnding::CRLF => self.0.line_ending = String::from("\u{000D}\u{000A}"),
+            LineEnding::Crlf => self.0.line_ending = String::from("\u{000D}\u{000A}"),
             LineEnding::VT => self.0.line_ending = String::from("\u{000B}"),
             LineEnding::FF => self.0.line_ending = String::from("\u{000C}"),
-            LineEnding::NEL => self.0.line_ending = String::from("\u{0085}"),
+            LineEnding::Nel => self.0.line_ending = String::from("\u{0085}"),
             LineEnding::LS => self.0.line_ending = String::from("\u{2028}"),
             LineEnding::PS => self.0.line_ending = String::from("\u{2029}"),
         }
@@ -403,7 +404,7 @@ impl Default for Config {
 
             #[cfg(feature = "paris")]
             enable_paris_formatting: true,
-            line_ending: '\n'
+            line_ending: String::from("\u{000A}"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,26 @@ pub(crate) enum TimeFormat {
     Custom(&'static [time::format_description::FormatItem<'static>]),
 }
 
+/// UTF-8 end of line character sequences
+pub enum LineEnding {
+    /// Line feed
+    LF,
+    /// Carriage return
+    CR,
+    /// Carriage return + Line feed
+    CRLF,
+    /// Vertical tab
+    VT,
+    /// Form feed
+    FF,
+    /// Next line
+    NEL,
+    /// Line separator
+    LS,
+    /// Paragraph separator
+    PS,
+}
+
 /// Configuration for the Loggers
 ///
 /// All loggers print the message in the following form:
@@ -89,6 +109,7 @@ pub struct Config {
     pub(crate) write_log_enable_colors: bool,
     #[cfg(feature = "paris")]
     pub(crate) enable_paris_formatting: bool,
+    pub(crate) line_ending: String,
 }
 
 impl Config {
@@ -119,6 +140,20 @@ impl ConfigBuilder {
     /// Create a new default ConfigBuilder
     pub fn new() -> ConfigBuilder {
         ConfigBuilder(Config::default())
+    }
+
+    pub fn set_line_ending(&mut self, line_ending: LineEnding) -> &mut ConfigBuilder {
+        match line_ending {
+            LineEnding::LF => self.0.line_ending = String::from("\u{000A}"),
+            LineEnding::CR => self.0.line_ending = String::from("\u{000D}"),
+            LineEnding::CRLF => self.0.line_ending = String::from("\u{000D}\u{000A}"),
+            LineEnding::VT => self.0.line_ending = String::from("\u{000B}"),
+            LineEnding::FF => self.0.line_ending = String::from("\u{000C}"),
+            LineEnding::NEL => self.0.line_ending = String::from("\u{0085}"),
+            LineEnding::LS => self.0.line_ending = String::from("\u{2028}"),
+            LineEnding::PS => self.0.line_ending = String::from("\u{2029}"),
+        }
+        self
     }
 
     /// Set at which level and above (more verbose) the level itself shall be logged (default is Error)
@@ -368,6 +403,7 @@ impl Default for Config {
 
             #[cfg(feature = "paris")]
             enable_paris_formatting: true,
+            line_ending: '\n'
         }
     }
 }

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -21,6 +21,11 @@ pub fn termcolor_to_ansiterm(color: &Color) -> Option<ansi_term::Color> {
     }
 }
 
+#[cfg(target_os = "windows")]
+const LINE_END: &str = "\r\n";
+#[cfg(not(target_os = "windows"))]
+const LINE_END: &str = "\n";
+
 #[inline(always)]
 pub fn try_log<W>(config: &Config, record: &Record<'_>, write: &mut W) -> Result<(), Error>
 where
@@ -231,13 +236,14 @@ pub fn write_args<W>(record: &Record<'_>, write: &mut W, with_colors: bool) -> R
 where
     W: Write + Sized,
 {
-    writeln!(
+    write!(
         write,
-        "{}",
+        "{}{}",
         crate::__private::paris::formatter::format_string(
             format!("{}", record.args()),
             with_colors
-        )
+        ),
+        LINE_END
     )?;
     Ok(())
 }
@@ -248,7 +254,7 @@ pub fn write_args<W>(record: &Record<'_>, write: &mut W) -> Result<(), Error>
 where
     W: Write + Sized,
 {
-    writeln!(write, "{}", record.args())?;
+    write!(write, "{}{}", record.args(), LINE_END)?;
     Ok(())
 }
 

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -21,11 +21,6 @@ pub fn termcolor_to_ansiterm(color: &Color) -> Option<ansi_term::Color> {
     }
 }
 
-#[cfg(feature = "crlf-line-endings")]
-const LINE_END: &str = "\r\n";
-#[cfg(not(feature = "crlf-line-endings"))]
-const LINE_END: &str = "\n";
-
 #[inline(always)]
 pub fn try_log<W>(config: &Config, record: &Record<'_>, write: &mut W) -> Result<(), Error>
 where
@@ -67,9 +62,9 @@ where
     }
 
     #[cfg(feature = "paris")]
-    return write_args(record, write, config.enable_paris_formatting);
+    return write_args(record, write, config.enable_paris_formatting, &config.line_ending);
     #[cfg(not(feature = "paris"))]
-    return write_args(record, write);
+    return write_args(record, write, &config.line_ending);
 }
 
 #[inline(always)]
@@ -232,7 +227,7 @@ where
 
 #[inline(always)]
 #[cfg(feature = "paris")]
-pub fn write_args<W>(record: &Record<'_>, write: &mut W, with_colors: bool) -> Result<(), Error>
+pub fn write_args<W>(record: &Record<'_>, write: &mut W, with_colors: bool, line_ending: &str) -> Result<(), Error>
 where
     W: Write + Sized,
 {
@@ -243,18 +238,18 @@ where
             format!("{}", record.args()),
             with_colors
         ),
-        LINE_END
+        line_ending
     )?;
     Ok(())
 }
 
 #[inline(always)]
 #[cfg(not(feature = "paris"))]
-pub fn write_args<W>(record: &Record<'_>, write: &mut W) -> Result<(), Error>
+pub fn write_args<W>(record: &Record<'_>, write: &mut W, line_ending: &str) -> Result<(), Error>
 where
     W: Write + Sized,
 {
-    write!(write, "{}{}", record.args(), LINE_END)?;
+    write!(write, "{}{}", record.args(), line_ending)?;
     Ok(())
 }
 

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -62,7 +62,12 @@ where
     }
 
     #[cfg(feature = "paris")]
-    return write_args(record, write, config.enable_paris_formatting, &config.line_ending);
+    return write_args(
+        record,
+        write,
+        config.enable_paris_formatting,
+        &config.line_ending,
+    );
     #[cfg(not(feature = "paris"))]
     return write_args(record, write, &config.line_ending);
 }
@@ -227,7 +232,12 @@ where
 
 #[inline(always)]
 #[cfg(feature = "paris")]
-pub fn write_args<W>(record: &Record<'_>, write: &mut W, with_colors: bool, line_ending: &str) -> Result<(), Error>
+pub fn write_args<W>(
+    record: &Record<'_>,
+    write: &mut W,
+    with_colors: bool,
+    line_ending: &str,
+) -> Result<(), Error>
 where
     W: Write + Sized,
 {

--- a/src/loggers/logging.rs
+++ b/src/loggers/logging.rs
@@ -21,9 +21,9 @@ pub fn termcolor_to_ansiterm(color: &Color) -> Option<ansi_term::Color> {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(feature = "crlf-line-endings")]
 const LINE_END: &str = "\r\n";
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(feature = "crlf-line-endings"))]
 const LINE_END: &str = "\n";
 
 #[inline(always)]

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -176,7 +176,12 @@ impl TermLogger {
         }
 
         #[cfg(feature = "paris")]
-        write_args(record, term_lock, self.config.enable_paris_formatting)?;
+        write_args(
+            record,
+            term_lock,
+            self.config.enable_paris_formatting,
+            &self.config.line_ending,
+        )?;
         #[cfg(not(feature = "paris"))]
         write_args(record, term_lock, &self.config.line_ending)?;
 

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -178,7 +178,7 @@ impl TermLogger {
         #[cfg(feature = "paris")]
         write_args(record, term_lock, self.config.enable_paris_formatting)?;
         #[cfg(not(feature = "paris"))]
-        write_args(record, term_lock)?;
+        write_args(record, term_lock, &self.config.line_ending)?;
 
         // The log crate holds the logger as a `static mut`, which isn't dropped
         // at program exit: https://doc.rust-lang.org/reference/items/static-items.html


### PR DESCRIPTION
Added a config option for different line endings. '\n' is quite ubiquitous but not used everywhere (Old versions of DOS/Windows). For the niche use cases were someone wants their log files to have a different line ending this could be helpful.