### PR TITLE
Add `TerminalMode::Custom` to use a custom stream for each `Level`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target
 Cargo.lock
 *.log
+.idea

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use self::config::{
 pub use self::loggers::TestLogger;
 pub use self::loggers::{CombinedLogger, SimpleLogger, WriteLogger};
 #[cfg(feature = "termcolor")]
-pub use self::loggers::{TermLogger, TerminalMode};
+pub use self::loggers::{Target, TermLogger, TerminalMode};
 #[cfg(feature = "termcolor")]
 pub use termcolor::{Color, ColorChoice};
 

--- a/src/loggers/mod.rs
+++ b/src/loggers/mod.rs
@@ -10,7 +10,7 @@ mod writelog;
 pub use self::comblog::CombinedLogger;
 pub use self::simplelog::SimpleLogger;
 #[cfg(feature = "termcolor")]
-pub use self::termlog::{TermLogger, TerminalMode};
+pub use self::termlog::{Target, TermLogger, TerminalMode};
 #[cfg(feature = "test")]
 pub use self::testlog::TestLogger;
 pub use self::writelog::WriteLogger;

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -28,12 +28,17 @@ pub enum TerminalMode {
     /// Use Stderr for Errors and Stdout otherwise
     #[default]
     Mixed,
-    /// Use custom streams
+    /// Use custom output streams
     Custom {
+        /// Stream for Error logs
         error: Target,
+        /// Stream for Warning logs
         warn: Target,
+        /// Stream for Info logs
         info: Target,
+        /// Stream for Debug logs
         debug: Target,
+        /// Stream for Trace logs
         trace: Target,
     },
 }

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -74,10 +74,9 @@ impl TerminalMode {
 }
 
 /// Possible target streams
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum Target {
     /// Use Stdout
-    #[default]
     Stdout,
     /// Use Stderr
     Stderr,


### PR DESCRIPTION
Add `TerminalMode::Custom` to use a custom stream for each `Level`.
I followed @Drakulix idea from #78.
Fixes #78.