### PR TITLE
Support log/kv feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ include = [
 test = []
 default = ["termcolor", "local-offset"]
 local-offset = ["time/local-offset"]
+# requires log >= 0.4.21
+kv = ["log/kv"]
 
 [dependencies]
 log = { version = "0.4.*", features = ["std"] }

--- a/examples/kv.rs
+++ b/examples/kv.rs
@@ -1,0 +1,30 @@
+#[cfg(feature = "kv")]
+fn main() {
+    use log::*;
+    use simplelog::*;
+
+    #[cfg(feature = "ansi_term")]
+    let config = ConfigBuilder::new()
+        .set_write_log_enable_colors(true)
+        .build();
+    #[cfg(not(feature = "ansi_term"))]
+    let config = Config::default();
+
+    TermLogger::init(
+        LevelFilter::Trace,
+        config,
+        TerminalMode::Stdout,
+        ColorChoice::Auto,
+    )
+    .unwrap();
+    error!(test = 1; "error with keys");
+    warn!(test = 2; "warning with keys");
+    info!(string = "value"; "info with keys");
+    debug!(dur = "5s"; "debug with keys");
+    trace!(test = 9000; "trace with keys");
+}
+
+#[cfg(not(feature = "kv"))]
+fn main() {
+    println!("this example requires the kv feature.");
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,8 @@ pub struct Config {
     pub(crate) filter_ignore: Cow<'static, [Cow<'static, str>]>,
     #[cfg(feature = "termcolor")]
     pub(crate) level_color: [Option<Color>; 6],
+    #[cfg(all(feature = "termcolor", feature = "kv"))]
+    pub(crate) kv_key_color: Option<Color>,
     pub(crate) write_log_enable_colors: bool,
     #[cfg(feature = "paris")]
     pub(crate) enable_paris_formatting: bool,
@@ -401,6 +403,8 @@ impl Default for Config {
                 Some(Color::Cyan),   // Debug
                 Some(Color::White),  // Trace
             ],
+            #[cfg(all(feature = "termcolor", feature = "kv"))]
+            kv_key_color: Some(Color::Yellow),
 
             #[cfg(feature = "paris")]
             enable_paris_formatting: true,

--- a/src/loggers/testlog.rs
+++ b/src/loggers/testlog.rs
@@ -129,6 +129,11 @@ pub fn log(config: &Config, record: &Record<'_>) {
     }
 
     write_args(record);
+
+    #[cfg(feature = "kv")]
+    let _ = record.key_values().visit(&mut KvTestPrinter);
+
+    println!();
 }
 
 #[inline(always)]
@@ -187,5 +192,24 @@ pub fn write_module(record: &Record<'_>) {
 
 #[inline(always)]
 pub fn write_args(record: &Record<'_>) {
-    println!("{}", record.args());
+    print!("{}", record.args());
+}
+
+#[cfg(feature = "kv")]
+struct KvTestPrinter;
+
+#[cfg(feature = "kv")]
+impl<'kv> log::kv::VisitSource<'kv> for KvTestPrinter<'kv>
+where
+    W: Write + Sized,
+{
+    fn visit_pair(
+        &mut self,
+        key: log::kv::Key<'kv>,
+        value: log::kv::Value<'kv>,
+    ) -> Result<(), log::kv::Error> {
+        print!(" {key}={value:?}");
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fix #148 

I'm not sure, if I tested all combination of cargo features

<details><summary>Example</summary>
<p>

```sh
cargo run --example=kv --features=kv
```

![image](https://github.com/user-attachments/assets/8fd38c9a-ba7c-4961-b217-a80a44d30c10)

</p>
</details> 